### PR TITLE
Fix Solaris defines for Endian-ness

### DIFF
--- a/kremlib/kremlib.h
+++ b/kremlib/kremlib.h
@@ -242,19 +242,19 @@ typedef const char *Prims_string;
 #elif defined(__sun__)
 #  include <sys/byteorder.h>
 #  define htole64(x) LE_64(x)
-#  define le64toh(x) LE_IN64(x)
+#  define le64toh(x) LE_64(x)
 #  define htobe64(x) BE_64(x)
-#  define be64toh(x) BE_IN64(x)
+#  define be64toh(x) BE_64(x)
 
 #  define htole16(x) LE_16(x)
-#  define le16toh(x) LE_IN16(x)
+#  define le16toh(x) LE_16(x)
 #  define htobe16(x) BE_16(x)
-#  define be16toh(x) BE_IN16(x)
+#  define be16toh(x) BE_16(x)
 
 #  define htole32(x) LE_32(x)
-#  define le32toh(x) LE_IN32(x)
+#  define le32toh(x) LE_32(x)
 #  define htobe32(x) BE_32(x)
-#  define be32toh(x) BE_IN32(x)
+#  define be32toh(x) BE_32(x)
 
 /* ... for the BSDs */
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)


### PR DESCRIPTION
Don't use variants with IN which expect pointer.

Sorry for the issue. Please see:

https://bugzilla.mozilla.org/show_bug.cgi?id=1405268
https://bugzilla.mozilla.org/show_bug.cgi?id=1419009

Now it should be hopefully right. I have created test program for these macros and I'm getting the same results as on Linux.