### PR TITLE
Kremlin cross-compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 .PHONY: all clean test
 
+ifdef CROSS
+  OCAMLLIB=$(abspath $(shell ocamlfind printconf path))
+  OCAMLBUILD=ocamlbuild -toolchain windows -I src -I lib -I parser -use-menhir -use-ocamlfind -classic-display \
+   -menhir "menhir --infer --explain" \
+	  -ocamldep "ocamldep -predicates custom_ppx -ppx '$(OCAMLLIB)/ppx_deriving/ppx_deriving $(OCAMLLIB)/ppx_deriving/ppx_deriving_show.cma $(OCAMLLIB)/ppx_deriving_yojson/ppx_deriving_yojson.cma'" \
+	  -ocamlc "ocamlc -predicates custom_ppx -ppx '$(OCAMLLIB)/ppx_deriving/ppx_deriving $(OCAMLLIB)/ppx_deriving/ppx_deriving_show.cma $(OCAMLLIB)/ppx_deriving_yojson/ppx_deriving_yojson.cma'" \
+	  -ocamlopt "ocamlopt -predicates custom_ppx -ppx '$(OCAMLLIB)/ppx_deriving/ppx_deriving $(OCAMLLIB)/ppx_deriving/ppx_deriving_show.cma $(OCAMLLIB)/ppx_deriving_yojson/ppx_deriving_yojson.cma'"
+else
 OCAMLBUILD=ocamlbuild -I src -I lib -I parser -use-menhir -use-ocamlfind -classic-display \
  -menhir "menhir --infer --explain"
+endif
+
 FLAVOR?=native
 TARGETS=Kremlin.$(FLAVOR) Tests.$(FLAVOR)
 


### PR DESCRIPTION
Not intended to be merged as is, just a demo to show that it doesn't take all that much. I just ran `CROSS=yes make` and, on a proper Ubuntu machine (no WSL) it gets me very swiftly to 
```
...:~/kremlin$ file _build/src/Kremlin.native 
_build/src/Kremlin.native: PE32+ executable (console) x86-64, for MS Windows
```

Those ppx options are a bit of a mess, I'm sure there's a nicer way to get those options through (e.g. in `_tags`, but I don't know how to get `$(OCAMLLIB)` into `_tags`).