### PR TITLE
Android/x86 requires limits.h to use SIZE_MAX macro

### DIFF
--- a/kremlib/kremlib.h
+++ b/kremlib/kremlib.h
@@ -2,6 +2,7 @@
 #define __KREMLIB_H
 
 #include <inttypes.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1439226

Since this library does't include limits.h, SIZE_MAX is undefined. So it requires this header.