### PR TITLE
More general measure for total while loops

### DIFF
--- a/kremlib/C.Loops.fst
+++ b/kremlib/C.Loops.fst
@@ -445,7 +445,7 @@ let repeat_range #a l min max f b fc =
 
 let rec total_while_gen
   (#t: Type)
-  (tmes: (t -> GTot nat))
+  (tmes: (t -> GTot lex_t))
   (tinv: (bool -> t -> GTot Type0))
   (tcontinue: (t -> Tot bool))
   (body:
@@ -454,7 +454,7 @@ let rec total_while_gen
     (requires (tinv true x))
     (ensures (fun y ->
       tinv (tcontinue y) y /\ (
-      if tcontinue y then tmes y < tmes x else True)
+      if tcontinue y then tmes y << tmes x else True)
     )))
   (x: t)
 : Pure t
@@ -487,7 +487,7 @@ let total_while
   (decreases (tmes x))
 = let (_, res) =
     total_while_gen
-      (fun (_, x) -> tmes x)
+      (fun (_, x) -> LexCons (tmes x) LexTop)
       (fun b (b_, x) -> b == b_ /\ tinv b x)
       (fun (x, _) -> x)
       (fun (_, x) -> body x)


### PR DESCRIPTION
The measure is not necessarily an integer, but it can be anything allowed in a decreases clause: `lex_t`, following advice from @mtzguido . This is why I propose to change the specification of the general case of total do-while loops, `total_while_gen`, accordingly.
`total_while_gen` is the total do-while loop combinator that is actually extracted to C, from which others are derived (and I will not change the specification of those derived combinators, to avoid breaking existing code.)
Tests show that changing the specification of measures has no impact on extraction, which is expected since measures are ghost data that are not even used while extracting the while loop.
