### PR TITLE
Allow reading KRML_HOME from environment

### DIFF
--- a/src/Driver.ml
+++ b/src/Driver.ml
@@ -142,8 +142,13 @@ let detect_kremlin () =
     KPrint.bprintf "%sthe Kremlin executable is:%s %s\n" Ansi.underline Ansi.reset real_krml;
 
     let krml_home =
-      try read_one_line !readlink [| "-f"; d real_krml ^^ ".." ^^ ".." |]
-      with _ -> fatal_error "Could not compute krml_home"
+      begin try
+        Sys.getenv "KRML_HOME"
+      with Not_found -> try
+        read_one_line !readlink [| "-f"; d real_krml ^^ ".." ^^ ".." |]
+      with _ ->
+        fatal_error "Could not compute krml_home"
+      end
     in
     KPrint.bprintf "%sKreMLin home is:%s %s\n" Ansi.underline Ansi.reset krml_home;
 


### PR DESCRIPTION
Hello,

this is a small patch I implemented for my local installation of kremlin to allow reading `KRML_HOME` from the environment - similar to how that is possible with `FSTAR_HOME`. I needed this because the assumption that `KRML_HOME` is always in the grandparent directory of the binary doesn't hold true in my environment.

I understand that this might be too specific to my setup as it doesn't seem to cause any problems for others. However I thought the patch might be helpful for various other reasons, so I decided to open a PR.

I apologize if I there are any coding errors - I don't really know OCaml, so I don't expect this to be bullet-proof. I mainly based it on how the `FSTAR_HOME` variable is read in the same file.

I could also not find any contribution guidelines, so I don't know if this PR or the commit messages are acceptable. Please let me know if I should change anything