### PR TITLE
Add macro to select the system's endian.h when __linux__ is undefined.

### DIFF
--- a/include/kremlin/c_endianness.h
+++ b/include/kremlin/c_endianness.h
@@ -12,7 +12,7 @@
 /******************************************************************************/
 
 /* ... for Linux */
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined (__USE_SYSTEM_ENDIAN_H__)
 #  include <endian.h>
 
 /* ... for OSX */


### PR DESCRIPTION
I'm using the musl libc in enclaves, which does not define any of the macros currently tested for in [c_endianness.h](https://github.com/FStarLang/kremlin/blob/master/include/kremlin/c_endianness.h). It's a feature of musl, not a bug. The feature detection macros they define are listed in their [manual](https://www.musl-libc.org/doc/1.0.0/manual.html). 

Further, `__linux__` is undefined in our builds of enclave objects. To get around the issue I artificially `#define __OpenBSD__`, but it would be much nicer if we had a different `#define` to select that regardless of the system feature macros.