### PR TITLE
Use -ccopts in final Makefile target

### DIFF
--- a/misc/Makefile.basic
+++ b/misc/Makefile.basic
@@ -29,6 +29,7 @@ OBJS 	+= $(patsubst %.c,%.o,$(SOURCES))
 all: $(USER_TARGET)
 
 $(USER_TARGET): $(OBJS)
+	$(CC) $(OBJS) $(USER_CFLAGS) -o $@
 
 AR ?= ar
 


### PR DESCRIPTION
This change allows the developer to add `-ccopts -lkremlib,-L$(KREMLIN_HOME)/kremlib/dist/generic` to their Makefile so that kremlib is linked in the final executable.

The behavior before was `cc C.o HelloWorld.o C_Endianness.o -o HelloWorld` which failed because it was missing the function body of `C_String_print` (call to undefined function), for example.