### PR TITLE
KRML_HOME -> KREMLIN_HOME

### DIFF
--- a/src/Driver.ml
+++ b/src/Driver.ml
@@ -157,7 +157,7 @@ let detect_kremlin () =
 
     let krml_home =
       begin try
-        Sys.getenv "KRML_HOME"
+        Sys.getenv "KREMLIN_HOME"
       with Not_found -> try
         let real_krml =
           let me = Sys.argv.(0) in


### PR DESCRIPTION
Nobody seems to be using KRML_HOME, but everybody in Project Everest is using KREMLIN_HOME instead.
