### PR TITLE
Include stdint for __int128

### DIFF
--- a/include/kremlin/internal/types.h
+++ b/include/kremlin/internal/types.h
@@ -7,6 +7,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 /* Types which are either abstract, meaning that have to be implemented in C, or
  * which are models, meaning that they are swapped out at compile-time for


### PR DESCRIPTION
stdint.h is required on older compilers to get __int128