### PR TITLE
check for aarch64; don't use deprecate on GCC <= 4.4

### DIFF
--- a/include/kremlin/internal/target.h
+++ b/include/kremlin/internal/target.h
@@ -99,8 +99,11 @@ inline static int32_t krml_time() {
 #  define KRML_HOST_SNPRINTF(buf, sz, fmt, arg) snprintf(buf, sz, fmt, arg)
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ > 4
 #  define KRML_DEPRECATED(x) __attribute__((deprecated(x)))
+#elif  defined(__GNUC__)
+// deprecated attribute is not defined in GCC < 4.5.
+#  define KRML_DEPRECATED(x)
 #elif defined(_MSC_VER)
 #  define KRML_DEPRECATED(x) __declspec(deprecated(x))
 #endif

--- a/include/kremlin/internal/types.h
+++ b/include/kremlin/internal/types.h
@@ -48,7 +48,8 @@ typedef uint64_t FStar_Date_dateTime, FStar_Date_timeSpan;
 #if !defined(KRML_VERIFIED_UINT128) && defined(_MSC_VER) && defined(_M_X64)
 #  include <emmintrin.h>
 typedef __m128i FStar_UInt128_uint128;
-#elif !defined(KRML_VERIFIED_UINT128) && !defined(_MSC_VER) && (defined(__x86_64__) || defined(__x86_64))
+#elif !defined(KRML_VERIFIED_UINT128) && !defined(_MSC_VER) && \
+      (defined(__x86_64__) || defined(__x86_64) || defined(__aarch64__))
 typedef unsigned __int128 FStar_UInt128_uint128;
 #else
 typedef struct FStar_UInt128_uint128_s {

--- a/kremlib/c/fstar_uint128.c
+++ b/kremlib/c/fstar_uint128.c
@@ -23,7 +23,8 @@
 #include "FStar_UInt_8_16_32_64.h"
 #include "C_Endianness.h"
 
-#if !defined(KRML_VERIFIED_UINT128) && !defined(_MSC_VER) && (defined(__x86_64__) || defined(__x86_64))
+#if !defined(KRML_VERIFIED_UINT128) && !defined(_MSC_VER) && \
+    (defined(__x86_64__) || defined(__x86_64) || defined(__aarch64__))
 
 /* GCC + using native unsigned __int128 support */
 


### PR DESCRIPTION
GCC <= 4.4 doesn't support the deprecated attribute.
On aarch64 we have unint128 as well.