### PR TITLE
Update OCaml version upper bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ key component of [Project Everest](https://project-everest.github.io/).
 
 ## Trying out KreMLin
 
-KreMLin requires OCaml (>= 4.05.0), OPAM, and a recent version of GNU make.
+KreMLin requires OCaml (>= 4.05.0, < 4.08.0), OPAM, and a recent version of GNU make.
 
 **Regarding GNU make:** On OSX, this may require you to install a recent GNU
 make via homebrew, and invoke `gmake` instead of `make`.


### PR DESCRIPTION
wasm 1.0 doesn't support OCaml >=4.08.0 and wasm 1.1 has incompatible APIs
See also #169