### PR TITLE
Fix build on s390x; related to #166

### DIFF
--- a/include/kremlin/internal/types.h
+++ b/include/kremlin/internal/types.h
@@ -52,7 +52,8 @@ typedef const char *Prims_string;
 #define IS_MSVC64 (defined(_MSC_VER) && defined(_M_X64) && !defined(__clang__))
 #define HAS_INT128 ((defined(__x86_64__) || defined(__x86_64) || \
                      defined(__aarch64__) || \
-                     (defined(__powerpc64__) && defined(__LITTLE_ENDIAN__))) || \
+                     (defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)) || \
+                     defined(__s390x__)) || \
                     (defined(_MSC_VER) && !defined(_M_X64) && defined(__clang__)))
 
 /* The uint128 type is a special case since we offer several implementations of

--- a/include/kremlin/internal/types.h
+++ b/include/kremlin/internal/types.h
@@ -49,19 +49,20 @@ typedef const char *Prims_string;
 
 /* The great static header headache. */
 
+#define IS_MSVC64 (defined(_MSC_VER) && defined(_M_X64) && !defined(__clang__))
+#define HAS_INT128 ((defined(__x86_64__) || defined(__x86_64) || \
+                     defined(__aarch64__) || \
+                     (defined(__powerpc64__) && defined(__LITTLE_ENDIAN__))) || \
+                    (defined(_MSC_VER) && !defined(_M_X64) && defined(__clang__)))
+
 /* The uint128 type is a special case since we offer several implementations of
  * it, depending on the compiler and whether the user wants the verified
  * implementation or not. */
-#if !defined(KRML_VERIFIED_UINT128) && defined(_MSC_VER) && defined(_M_X64) && \
-    !defined(__clang__)
+#if !defined(KRML_VERIFIED_UINT128) && IS_MSVC64
 #  include <emmintrin.h>
 typedef __m128i FStar_UInt128_uint128;
-#elif !defined(KRML_VERIFIED_UINT128) && !defined(_MSC_VER) && \
-      (defined(__x86_64__) || defined(__x86_64) || defined(__aarch64__) || \
-      (defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)))
+#elif !defined(KRML_VERIFIED_UINT128) && HAS_INT128
 typedef unsigned __int128 FStar_UInt128_uint128;
-#elif !defined(KRML_VERIFIED_UINT128) && defined(_MSC_VER) && defined(__clang__)
-typedef __uint128_t FStar_UInt128_uint128;
 #else
 typedef struct FStar_UInt128_uint128_s {
   uint64_t low;
@@ -75,15 +76,13 @@ typedef FStar_UInt128_uint128 FStar_UInt128_t, uint128_t;
 
 #include "kremlin/lowstar_endianness.h"
 
-/* This one is always included, because it defines C.Endianness functions too. */
-#if !defined(_MSC_VER) || defined(__clang__)
+#if !defined(KRML_VERIFIED_UINT128) && HAS_INT128
 #include "fstar_uint128_gcc64.h"
-#endif
-
-#if !defined(KRML_VERIFIED_UINT128) && defined(_MSC_VER) && !defined(__clang__)
+#if !defined(KRML_VERIFIED_UINT128) && IS_MSVC64
 #include "fstar_uint128_msvc.h"
 #elif defined(KRML_VERIFIED_UINT128)
 #include "FStar_UInt128_Verified.h"
+#include "fstar_uint128_struct_endianness.h"
 #endif
 
 

--- a/kremlib/c/fstar_uint128_gcc64.h
+++ b/kremlib/c/fstar_uint128_gcc64.h
@@ -24,10 +24,6 @@
 #include "FStar_UInt_8_16_32_64.h"
 #include "LowStar_Endianness.h"
 
-#if !defined(KRML_VERIFIED_UINT128) && (!defined(_MSC_VER) || defined(__clang__)) && \
-      (defined(__x86_64__) || defined(__x86_64) || defined(__aarch64__) || \
-      (defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)))
-
 /* GCC + using native unsigned __int128 support */
 
 inline static uint128_t load128_le(uint8_t *b) {
@@ -162,67 +158,3 @@ inline static bool FStar_UInt128_lte(uint128_t x, uint128_t y) {
 inline static uint128_t FStar_UInt128_mul32(uint64_t x, uint32_t y) {
   return (uint128_t) x * (uint128_t) y;
 }
-
-#elif !defined(_MSC_VER) && defined(KRML_VERIFIED_UINT128)
-
-/* Verified uint128 implementation. */
-
-/* Access 64-bit fields within the int128. */
-#define HIGH64_OF(x) ((x)->high)
-#define LOW64_OF(x)  ((x)->low)
-
-/* A series of definitions written using pointers. */
-
-inline static void load128_le_(uint8_t *b, uint128_t *r) {
-  LOW64_OF(r) = load64_le(b);
-  HIGH64_OF(r) = load64_le(b + 8);
-}
-
-inline static void store128_le_(uint8_t *b, uint128_t *n) {
-  store64_le(b, LOW64_OF(n));
-  store64_le(b + 8, HIGH64_OF(n));
-}
-
-inline static void load128_be_(uint8_t *b, uint128_t *r) {
-  HIGH64_OF(r) = load64_be(b);
-  LOW64_OF(r) = load64_be(b + 8);
-}
-
-inline static void store128_be_(uint8_t *b, uint128_t *n) {
-  store64_be(b, HIGH64_OF(n));
-  store64_be(b + 8, LOW64_OF(n));
-}
-
-#    ifndef KRML_NOSTRUCT_PASSING
-
-inline static uint128_t load128_le(uint8_t *b) {
-  uint128_t r;
-  load128_le_(b, &r);
-  return r;
-}
-
-inline static void store128_le(uint8_t *b, uint128_t n) {
-  store128_le_(b, &n);
-}
-
-inline static uint128_t load128_be(uint8_t *b) {
-  uint128_t r;
-  load128_be_(b, &r);
-  return r;
-}
-
-inline static void store128_be(uint8_t *b, uint128_t n) {
-  store128_be_(b, &n);
-}
-
-#    else /* !defined(KRML_STRUCT_PASSING) */
-
-#      define print128 print128_
-#      define load128_le load128_le_
-#      define store128_le store128_le_
-#      define load128_be load128_be_
-#      define store128_be store128_be_
-
-#    endif /* KRML_STRUCT_PASSING */
-
-#endif

--- a/kremlib/c/fstar_uint128_struct_endianness.h
+++ b/kremlib/c/fstar_uint128_struct_endianness.h
@@ -1,0 +1,68 @@
+/* Copyright (c) INRIA and Microsoft Corporation. All rights reserved.
+   Licensed under the Apache 2.0 License. */
+
+#ifndef FSTAR_UINT128_STRUCT_ENDIANNESS_H
+#define FSTAR_UINT128_STRUCT_ENDIANNESS_H
+
+/* Hand-written implementation of endianness-related uint128 functions
+ * for the extracted uint128 implementation */
+
+/* Access 64-bit fields within the int128. */
+#define HIGH64_OF(x) ((x)->high)
+#define LOW64_OF(x)  ((x)->low)
+
+/* A series of definitions written using pointers. */
+
+inline static void load128_le_(uint8_t *b, uint128_t *r) {
+  LOW64_OF(r) = load64_le(b);
+  HIGH64_OF(r) = load64_le(b + 8);
+}
+
+inline static void store128_le_(uint8_t *b, uint128_t *n) {
+  store64_le(b, LOW64_OF(n));
+  store64_le(b + 8, HIGH64_OF(n));
+}
+
+inline static void load128_be_(uint8_t *b, uint128_t *r) {
+  HIGH64_OF(r) = load64_be(b);
+  LOW64_OF(r) = load64_be(b + 8);
+}
+
+inline static void store128_be_(uint8_t *b, uint128_t *n) {
+  store64_be(b, HIGH64_OF(n));
+  store64_be(b + 8, LOW64_OF(n));
+}
+
+#ifndef KRML_NOSTRUCT_PASSING
+
+inline static uint128_t load128_le(uint8_t *b) {
+  uint128_t r;
+  load128_le_(b, &r);
+  return r;
+}
+
+inline static void store128_le(uint8_t *b, uint128_t n) {
+  store128_le_(b, &n);
+}
+
+inline static uint128_t load128_be(uint8_t *b) {
+  uint128_t r;
+  load128_be_(b, &r);
+  return r;
+}
+
+inline static void store128_be(uint8_t *b, uint128_t n) {
+  store128_be_(b, &n);
+}
+
+#else /* !defined(KRML_STRUCT_PASSING) */
+
+#  define print128 print128_
+#  define load128_le load128_le_
+#  define store128_le store128_le_
+#  define load128_be load128_be_
+#  define store128_be store128_be_
+
+#endif /* KRML_STRUCT_PASSING */
+
+#endif


### PR DESCRIPTION
Even after #166 got merged, the NSS build is still failing on s390x as mentioned in:
https://bugzilla.mozilla.org/show_bug.cgi?id=1615557

The architecture has [several differences from other arches](https://fedoraproject.org/wiki/Architectures/s390x), but with this change, the build succeeds:
* https://src.fedoraproject.org/rpms/nss/blob/master/f/nss-kremlin-ppc64le.patch
* https://koji.fedoraproject.org/koji/buildinfo?buildID=1463542