### PR TITLE
Undefine low and high at the end of fstar_uint128_msvc.h

### DIFF
--- a/kremlib/c/fstar_uint128_msvc.h
+++ b/kremlib/c/fstar_uint128_msvc.h
@@ -465,3 +465,6 @@ FStar_UInt128_uint128 FStar_UInt128_mul_wide(uint64_t x, uint64_t y) {
   return FStar_UInt128_mul_wide_impl(x, y);
 #endif
 }
+
+#undef low
+#undef high


### PR DESCRIPTION
Letting them leak outside of the header can break unrelated code: https://github.com/project-everest/hacl-star/issues/316.