### PR TITLE
Enable the use of intrinsics in wasm code

### DIFF
--- a/src/CFlatToWasm.ml
+++ b/src/CFlatToWasm.ml
@@ -61,10 +61,20 @@ let name_of_string = W.Utf8.decode
 let string_of_name = W.Ast.string_of_name
 
 let rec find_func env name =
-  try
-    StringMap.find name env.funcs
-  with Not_found ->
-    Warn.fatal_error "%a: Could not resolve function %s" ploc env.location name
+    try
+      StringMap.find name env.funcs
+    with Not_found ->
+      begin
+        (* If the function is a fallback implementation of an intrinsic, find it
+         * using its correct name *)
+        match name with
+        | "Lib_IntTypes_Intrinsics_add_carry_u64" ->
+          find_func env "Hacl_IntTypes_Intrinsics_add_carry_u64"
+        | "Lib_IntTypes_Intrinsics_sub_borrow_u64" ->
+          find_func env "Hacl_IntTypes_Intrinsics_sub_borrow_u64"
+        | _ ->
+          Warn.fatal_error "%a: Could not resolve function %s" ploc env.location name
+      end
 
 let primitives = [
   "load32_le";

--- a/src/CFlatToWasm.ml
+++ b/src/CFlatToWasm.ml
@@ -61,10 +61,10 @@ let name_of_string = W.Utf8.decode
 let string_of_name = W.Ast.string_of_name
 
 let rec find_func env name =
-    try
-      StringMap.find name env.funcs
-    with Not_found ->
-      Warn.fatal_error "%a: Could not resolve function %s" ploc env.location name
+  try
+    StringMap.find name env.funcs
+  with Not_found ->
+    Warn.fatal_error "%a: Could not resolve function %s" ploc env.location name
 
 let primitives = [
   "load32_le";

--- a/src/Kremlin.ml
+++ b/src/Kremlin.ml
@@ -653,8 +653,10 @@ Supported options:|}
     if List.length is_support = 0 then
       Warn.fatal_error "The module WasmSupport wasn't passed to kremlin or \
         was hidden in a bundle!";
-    let files = is_support @ rest in
 
+    (* If present, place the fallback intrinsics module immediately after. *)
+    let intrinsics, rest = List.partition (fun (name, _) -> name = "Hacl_IntTypes_Intrinsics") rest in
+    let files = is_support @ intrinsics @ rest in
     (* The Wasm backend diverges here. We go to [CFlat] (an expression
      * language), then directly into the Wasm AST. *)
     let files = AstToCFlat.mk_files files c_name_map in


### PR DESCRIPTION
Attempting to extract code which relies on compiler intrinsics to wasm currently fails as the required functions are not present. This PR fixes this by making sure the wasm functions from the fallback F* implementations of intrinsics are always in scope and that their names can be resolved when extracting code that uses them.