### PR TITLE
define KRML_HOST_EPRINTF when building with MSVC

### DIFF
--- a/include/kremlin/internal/target.h
+++ b/include/kremlin/internal/target.h
@@ -26,6 +26,8 @@
     (defined __STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&             \
     (!(defined KRML_HOST_EPRINTF)))
 #  define KRML_HOST_EPRINTF(...) fprintf(stderr, __VA_ARGS__)
+#elif !(defined KRML_HOST_EPRINTF) && defined(_MSC_VER)
+#  define KRML_HOST_EPRINTF(...) fprintf(stderr, __VA_ARGS__)
 #endif
 
 #ifndef KRML_HOST_EXIT


### PR DESCRIPTION
I finally got around to do the [evecrypt rust bindings for Windows](https://github.com/franziskuskiefer/evercrypt-rust/tree/windows-builds). It turned out that it doesn't actually work unless I'm missing something (I wonder if anyone is using hacl on Windows 😬 ).
This PR fixes the Windows builds for me.