### PR TITLE
Set custom JS printer function in loader

### DIFF
--- a/kremlib/js/loader.js
+++ b/kremlib/js/loader.js
@@ -477,8 +477,14 @@ function link(imports, modules) {
   return fold(i, modules);
 }
 
+function setMyPrint(f) {
+  my_print = f;
+  return;
+}
+
 if (typeof module !== "undefined")
   module.exports = {
+    setMyPrint: setMyPrint,
     link: link,
     reserve: reserve,
     dump: dump,


### PR DESCRIPTION
This MR allows setting a custom printer in loader.js, which can also be used to silence output