### PR TITLE
Update OCaml versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ key component of [Project Everest](https://project-everest.github.io/).
 
 ## Trying out KreMLin
 
-KreMLin requires OCaml (>= 4.05.0, < 4.10.0), OPAM, and a recent version of GNU make.
+KreMLin requires OCaml (>= 4.08.0, <= 4.12.0), OPAM, and a recent version of GNU make.
 
 **Regarding GNU make:** On OSX, this may require you to install a recent GNU
 make via homebrew, and invoke `gmake` instead of `make`.


### PR DESCRIPTION
A common error during KreMLin compilation seems to be
```
File "src/CFlatToWasm.ml", line 196, characters 18-32:
Error: Unbound constructor W.Ast.LocalTee
```

This occurs when the version of the `wasm` package is too old. More recent versions are not supported with OCaml < 4.08.0.

This PR fixes the README to indicate that KreMLin >= 4.08.0 is required.