### PR TITLE
Grow the WASM memory if the data being passed in is too large to fit …

### DIFF
--- a/kremlib/js/loader.js
+++ b/kremlib/js/loader.js
@@ -448,7 +448,15 @@ function propagate(module_name, imports, instance) {
 function reserve(mem, size) {
   let m32 = new Uint32Array(mem.buffer);
   let p = m32[0];
-  m32[0] += size;
+  let curr = mem.byteLength;
+  let want = p + size;
+  if (want > curr) {
+    // The number of WebAssembly pages you want to grow the memory by (each one is 64KiB in size).
+    let need = Math.ceil((want - curr) / (64 * 1024)) + 1;
+    // One extra page for suitable stack space.
+    mem.grow(need);
+  }
+  m32[0] = want;
   // my_print("Reserved memory area 0x"+p32(p)+"..0x"+p32(m32[0]));
   return p;
 }


### PR DESCRIPTION
…in the memory. This fixes #217