### PR TITLE
Mark projectors and discriminators as private by default

### DIFF
--- a/src/Simplify.ml
+++ b/src/Simplify.ml
@@ -409,6 +409,17 @@ let remove_uu = object (self)
       ELet (b, e1, e2)
 end
 
+let remove_proj_is = object
+
+  inherit [_] map
+
+  method! visit_DFunction _ cc flags n t name binders body =
+    if KString.starts_with (snd name) "__proj__" || KString.starts_with (snd name) "__is__" then
+      DFunction (cc, Private :: flags, n, t, name, binders, body)
+    else
+      DFunction (cc, flags, n, t, name, binders, body)
+end
+
 
 (* Convert back and forth between [e1; e2] and [let _ = e1 in e2]. ************)
 
@@ -1634,6 +1645,7 @@ let simplify0 (files: file list): file list =
   let files = remove_local_function_bindings#visit_files () files in
   let files = count_and_remove_locals#visit_files [] files in
   let files = remove_uu#visit_files () files in
+  let files = remove_proj_is#visit_files () files in
   let files = combinators#visit_files () files in
   let files = wrapping_arithmetic#visit_files () files in
   files


### PR DESCRIPTION
Meaning their prototypes will be eliminated from public headers, or will go into internal headers (unlikely) rather than show up in the public C API.

This is another big code-quality improvement, to be reviewed after #219 