### PR TITLE
Support null and is_null Steel functions.

### DIFF
--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -199,6 +199,12 @@ let dyn: file =
       with_type void_star (ECast (with_type (TBound 0) (EBound 0), void_star)))
   ]
 
+let steel_reference : file =
+  "Steel_Reference", [
+    mk_val [ "Steel"; "Reference" ] "is_null" (TArrow (TBuf (TAny, false), TBool));
+    mk_val [ "Steel"; "Reference" ] "null" (TArrow (TAny, TBuf (TAny, false)));
+  ]
+
 let lowstar_monotonic_buffer: file =
   "LowStar_Monotonic_Buffer", [
     mk_val [ "LowStar"; "Monotonic"; "Buffer" ] "is_null" (TArrow (TBuf (TAny, false), TBool));
@@ -298,6 +304,7 @@ let lib_memzero0: file =
 (* These modules are entirely written by hand in abstract syntax. *)
 let hand_written = [
   buffer;
+  steel_reference;
   lowstar_monotonic_buffer;
   lowstar_buffer;
   lowstar_endianness;

--- a/src/CStarToC11.ml
+++ b/src/CStarToC11.ml
@@ -18,6 +18,8 @@ let builtin_names =
     ["C"; "Nullity"], "is_null";
     ["LowStar"; "Monotonic"; "Buffer"], "mnull";
     ["LowStar"; "Buffer"], "null";
+    ["Steel"; "Reference"], "null";
+    ["Steel"; "Reference"], "is_null";
     ["C"; "Nullity"], "null";
     ["C"; "String"], "get";
     ["C"; "String"], "t";
@@ -905,10 +907,12 @@ and mk_expr m (e: expr): C.expr =
 
   | Call (Qualified ([ "LowStar"; "Monotonic"; "Buffer" ], "mnull"), _)
   | Call (Qualified ([ "LowStar"; "Buffer" ], "null"), _)
+  | Call (Qualified ([ "Steel"; "Reference" ], "null"), _)
   | Call (Qualified ([ "C"; "Nullity" ], "null"), _) ->
       Name "NULL"
 
   | Call (Qualified ( [ "LowStar"; "Monotonic"; "Buffer" ], "is_null"), [ e ] )
+  | Call (Qualified ( [ "Steel"; "Reference" ], "is_null"), [ e ] )
   | Call (Qualified ( [ "C"; "Nullity" ], "is_null"), [ e ]) ->
       Op2 (K.Eq, mk_expr m e, C.Name "NULL")
 

--- a/src/Helpers.ml
+++ b/src/Helpers.ml
@@ -176,7 +176,7 @@ let is_union = function TAnonymous (Union _) -> true | _ -> false
 let is_null = function
   | { node = EApp (
       { node = EQualified (
-          ([ "LowStar"; "Buffer" ] | [ "C"; "Nullity" ]), "null" |
+          ([ "LowStar"; "Buffer" ] | [ "Steel"; "Reference" ] | [ "C"; "Nullity" ]), "null" |
           ([ "LowStar"; "Monotonic"; "Buffer" ], "mnull"));
         _ }, _); _ }
   ->
@@ -239,6 +239,7 @@ let is_readonly_builtin_lid lid =
     [ "FStar"; "UInt32" ], "v";
     [ "FStar"; "UInt128" ], "uint128_to_uint64";
     [ "LowStar"; "Monotonic"; "Buffer" ], "mnull";
+    [ "Steel"; "Reference" ], "null";
   ] in
   List.exists (fun lid' ->
     let lid = Idents.string_of_lident lid in

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,7 +45,7 @@ FSTAR		= $(FSTAR_EXE) --cache_checked_modules \
   --include hello-system --include ../kremlib/compat --include ../kremlib/obj \
   --include ../kremlib --include ../runtime \
   --include $(CRYPTO) --include ../book --include ../book/notfslit --use_hints --record_hints \
-  --already_cached 'Prims FStar C TestLib Spec.Loops -C.Compat -C.Nullity LowStar WasmSupport' \
+  --already_cached 'Prims FStar C TestLib Spec.Loops -C.Compat -C.Nullity LowStar WasmSupport Steel' \
   --trivial_pre_for_unannotated_effectful_fns false \
   --cmi --warn_error -274
 
@@ -75,6 +75,9 @@ endif
 
 include .depend
 
+# AF: The Steel files should not be extracted by KreMLin, they are filtered out
+FILTERED_KRML_FILES = $(filter-out $(OUTPUT_DIR)/FStar_NMST.krml $(OUTPUT_DIR)/Steel_%.krml,$(ALL_KRML_FILES))
+
 $(HINTS_DIR):
 	mkdir -p $@
 
@@ -87,13 +90,13 @@ $(OUTPUT_DIR)/%.krml: | .depend
 	  --extract_module $(basename $(notdir $(subst .checked,,$<))) \
 	  $(notdir $(subst .checked,,$<))
 
-$(OUTPUT_DIR)/Ctypes2.exe: $(ALL_KRML_FILES) $(KRML_BIN)
+$(OUTPUT_DIR)/Ctypes2.exe: $(FILTERED_KRML_FILES) $(KRML_BIN)
 	$(KRML) $(EXTRA) -tmpdir $(subst .exe,.out,$@) \
 	  -o $@ $(filter %.krml,$^) \
         -skip-compilation $(filter %.krml,$^) \
 
 .PRECIOUS: $(OUTPUT_DIR)/%.exe
-$(OUTPUT_DIR)/%.exe: $(filter-out %/prims.krml,$(ALL_KRML_FILES)) $(KRML_BIN)
+$(OUTPUT_DIR)/%.exe: $(filter-out %/prims.krml,$(FILTERED_KRML_FILES)) $(KRML_BIN)
 	$(KRML) $(EXTRA) -tmpdir $(subst .exe,.out,$@) -no-prefix $(notdir $*) \
 	  -o $@ $(filter %.krml,$^) -bundle $(subst _,.,$*)=WindowsHack,\*
 
@@ -188,7 +191,7 @@ $(LOWLEVEL_DIR)/Client.native: $(OUTPUT_DIR)/Ctypes2.exe $(addprefix $(LOWLEVEL_
 # All WASM targets get the -wasm flag; some specific targets may override
 # NEGATIVE for negative tests.
 .PRECIOUS: $(OUTPUT_DIR)/%.wasm
-$(OUTPUT_DIR)/%.wasm: $(filter-out %/prims.krml,$(ALL_KRML_FILES)) $(KRML_BIN)
+$(OUTPUT_DIR)/%.wasm: $(filter-out %/prims.krml,$(FILTERED_KRML_FILES)) $(KRML_BIN)
 	$(KRML) -minimal -bundle WasmSupport= -bundle 'FStar.*' -bundle Prims \
 	  -bundle C -bundle C.Endianness -bundle C.Nullity -bundle C.String \
 	  -bundle TestLib \

--- a/test/SteelNotNull.fst
+++ b/test/SteelNotNull.fst
@@ -1,0 +1,14 @@
+module SteelNotNull
+
+open Steel.Effect
+open Steel.Reference
+
+let main () : SteelT UInt32.t emp (fun _ -> emp) =
+  let r = malloc 0ul in
+  if is_null r then (
+    free r;
+    1ul
+  ) else (
+    free r;
+    0ul
+  )

--- a/test/SteelNotNull.fst
+++ b/test/SteelNotNull.fst
@@ -3,12 +3,12 @@ module SteelNotNull
 open Steel.Effect
 open Steel.Reference
 
-let main () : SteelT UInt32.t emp (fun _ -> emp) =
+let main () : SteelT Int32.t emp (fun _ -> emp) =
   let r = malloc 0ul in
   if is_null r then (
     free r;
-    1ul
+    1l
   ) else (
     free r;
-    0ul
+    0l
   )

--- a/test/SteelNull.fst
+++ b/test/SteelNull.fst
@@ -1,11 +1,12 @@
 module SteelNull
 
+open Steel.Effect.Atomic
 open Steel.Effect
 open Steel.Reference
 
-let main () =
+let main () : SteelT Int32.t emp (fun _ -> emp) =
   let r = null #UInt32.t in
   if is_null r then
-    0ul
+    return 0l
   else
-    1ul
+    return 1l

--- a/test/SteelNull.fst
+++ b/test/SteelNull.fst
@@ -1,0 +1,11 @@
+module SteelNull
+
+open Steel.Effect
+open Steel.Reference
+
+let main () =
+  let r = null #UInt32.t in
+  if is_null r then
+    0ul
+  else
+    1ul


### PR DESCRIPTION
@cmovcc reported failures when attempting to compile C code extracted from Steel. In particular, references to Steel_Reference_null and Steel_Reference_is_null were undefined.

This PR adds support for these two functions, similarly to existing support for LowStar.Buffer.null and LowStar.Buffer.is_null.