### PR TITLE
Fix OPAM build

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ install coreutils`).
 If you have the right version of F\* and `fstar.exe` is in your `PATH` then you
 can run the KreMLin test suite by doing `make test`.
 
+## Installing through OPAM
+
+KreMLin is also available on OPAM, by running `opam install kremlin`.
+
+If you installed the latest version of F* through OPAM, using `opam pin add fstar --dev-repo`,
+you can also install the most up-to-date version of KreMLin by running `opam pin add kremlin --dev-repo`.
+
 File a bug if things don't work!
 
 ## Documentation

--- a/kremlib/Makefile
+++ b/kremlib/Makefile
@@ -100,6 +100,7 @@ $(GENERIC_DIR):
 
 # Everything in the universe
 $(GENERIC_DIR)/Makefile.include: $(ALL_KRML_FILES) | $(GENERIC_DIR) $(wildcard c/*.c) $(wildcard c/*.h) ../_build/src/Kremlin.native
+	KREMLIN_HOME=$(shell pwd)/.. \
 	../krml $(KREMLIN_ARGS) -tmpdir $(GENERIC_DIR) \
 	  -warn-error +9+11 \
 	  $(MACHINE_INTS) \

--- a/kremlin.opam
+++ b/kremlin.opam
@@ -40,7 +40,7 @@ remove: [
 ]
 dev-repo: "git+https://github.com/FStarLang/kremlin"
 bug-reports: "https://github.com/FStarLang/kremlin/issues"
-synopsis: "A compiler from Low*, a low-level subset of F*, to C."
+synopsis: "A compiler from Low*, a low-level subset of F*, to C"
 flags: light-uninstall
 url {
   src: "https://github.com/FStarLang/kremlin/archive/refs/tags/v1.0.0.zip"

--- a/kremlin.opam
+++ b/kremlin.opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "protz@microsoft.com"
+authors: "Jonathan Protzenko <jonathan.protzenko@gmail.com>"
+homepage: "https://github.com/fstarlang/kremlin"
+license: "Apache-2.0"
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.13.0"}
+  "ocamlfind" {build}
+  "batteries"
+  "zarith"
+  "stdint"
+  "yojson"
+  "ocamlbuild" {build}
+  "fileutils"
+  "menhir" {>= "20161115"}
+  "pprint"
+  "ulex"
+  "process"
+  "fix"
+  "visitors"
+  "wasm"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "fstar"
+]
+depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
+build: [
+  [make "PREFIX=%{prefix}%"]
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"]
+]
+remove: [
+  [ "rm" "-rf"
+      "%{prefix}%/lib/kremlin"
+      "%{prefix}%/include/kremlin"
+      "%{prefix}%/doc/kremlin"
+      "%{prefix}%/bin/krml"
+      "%{prefix}%/share/kremlin" ]
+]
+dev-repo: "git+https://github.com/FStarLang/kremlin"
+bug-reports: "https://github.com/FStarLang/kremlin/issues"
+synopsis: "A compiler from Low*, a low-level subset of F*, to C."
+flags: light-uninstall
+url {
+  src: "https://github.com/FStarLang/kremlin/archive/refs/tags/v1.0.0.zip"
+  checksum: [
+    "md5=683260ca8947fcb0ce134cb8385193fc"
+    "sha512=d63930487484d82114c7621a34fd31923bacb735aafdb6c9fe4d6de45c01b6a31cff235abcc2e22d2a1445b9b17d321023d2e731c725986021d371be36a6df6b"
+  ]
+}

--- a/src/Driver.ml
+++ b/src/Driver.ml
@@ -145,7 +145,7 @@ let detect_base_tools_if () =
 let detect_kremlin () =
   detect_base_tools_if ();
 
-  if AutoConfig.kremlib_dir <> "" then begin
+  if AutoConfig.kremlib_dir <> "" && try ignore (Sys.getenv "KREMLIN_HOME"); false with Not_found -> true then begin
     kremlib_dir := AutoConfig.kremlib_dir;
     runtime_dir := AutoConfig.runtime_dir;
     include_dir := AutoConfig.include_dir;


### PR DESCRIPTION
Fixes Makefile to set the correct environment variables for opam installation.
Also adds a kremlin.opam file for building through opam with the --dev-repo option