### PR TITLE
Add missing KREMLIN_HOME primitives in kremlib/Makefile for opam install

### DIFF
--- a/kremlib/Makefile
+++ b/kremlib/Makefile
@@ -135,6 +135,7 @@ $(MINI_DIR)/Makefile.include: $(ALL_KRML_FILES) | $(MINI_DIR) $(wildcard c/fstar
 # FStar.UInt64 shares the same bundle name, meaning that
 # FStar_UInt128_Verified.h can be dropped in any of the two kremlibs above.
 $(UINT128_DIR)/Makefile.include: $(ALL_KRML_FILES) | $(GENERIC_DIR) $(MINI_DIR) ../_build/src/Kremlin.native
+	KREMLIN_HOME=$(shell pwd)/.. \
 	../krml $(KREMLIN_ARGS) -tmpdir $(UINT128_DIR) \
 	  $(addprefix -add-include ,'<inttypes.h>' '<stdbool.h>' '"kremlin/internal/types.h"' '"kremlin/internal/target.h"') \
 	  -bundle FStar.UInt64[rename=FStar_UInt_8_16_32_64] \
@@ -159,4 +160,5 @@ compile-all: compile-dist-generic $(MINI_DIR)/Makefile.include $(UINT128_DIR)/Ma
 
 .PHONY: compile-dist-%
 compile-dist-%: dist/%/Makefile.include
+	KREMLIN_HOME=$(shell pwd)/.. \
 	$(MAKE) -C dist/$* -f Makefile.basic


### PR DESCRIPTION
When installing through Opam, KREMLIN_HOME was not set during installation, leading to errors when building dist/generic. See for instance https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/0cbfb6fe715e61ba1c5ca6e3a0a8eb7cad931522.