### PR TITLE
Update build instructions to reflect lower bounds on some packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make via homebrew, and invoke `gmake` instead of `make`.
 
 **Regarding OCaml:** Install OPAM via your package manager, then:
 
-`$ opam install ppx_deriving_yojson zarith pprint menhir sedlex process fix wasm visitors ctypes-foreign ctypes`
+`$ opam install ppx_deriving_yojson zarith pprint "menhir>=20161115" sedlex process fix "wasm>=1.1.1" visitors ctypes-foreign ctypes`
 
 Next, make sure you have an up-to-date F\*, and that you ran `make` in the
 `ulib/ml` directory of F\*. The `fstar.exe` executable should be on your PATH

--- a/kremlin.opam
+++ b/kremlin.opam
@@ -18,7 +18,7 @@ depends: [
   "process"
   "fix"
   "visitors"
-  "wasm"
+  "wasm" {>= "1.1.1"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "fstar"


### PR DESCRIPTION
Fixing the lower bound of wasm=1.1.1 required, and updating the README accordingly to ensure that the installation of opam dependencies fetches compatible versions.