### PR TITLE
New syntax for adding #includes in C files only

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+### Feb 14th, 2022
+
+New option syntax: `-add-include 'Foobar.c:XXX'` results in `#include XXX`
+prepended only in the C file.
+
 ### Dec 29th, 2021
 
 Eliminate projectors and discriminators unless otherwise necessary.

--- a/kremlib/Makefile
+++ b/kremlib/Makefile
@@ -100,7 +100,6 @@ $(GENERIC_DIR):
 
 # Everything in the universe
 $(GENERIC_DIR)/Makefile.include: $(ALL_KRML_FILES) | $(GENERIC_DIR) $(wildcard c/*.c) $(wildcard c/*.h) ../_build/src/Kremlin.native
-	KREMLIN_HOME=$(shell pwd)/.. \
 	../krml $(KREMLIN_ARGS) -tmpdir $(GENERIC_DIR) \
 	  -warn-error +9+11 \
 	  $(MACHINE_INTS) \

--- a/src/Options.ml
+++ b/src/Options.ml
@@ -1,6 +1,13 @@
 (* Copyright (c) INRIA and Microsoft Corporation. All rights reserved. *)
 (* Licensed under the Apache 2.0 License. *)
 
+type include_ = All | HeaderOnly of string | COnly of string
+
+let pinc b = function
+  | All -> Buffer.add_string b "*"
+  | HeaderOnly h -> Buffer.add_string b h; Buffer.add_string b ".h"
+  | COnly h -> Buffer.add_string b h; Buffer.add_string b ".c"
+
 (** Some of these will be filled by [Driver].  *)
 let no_prefix: Bundle.pat list ref = ref Bundle.[
   Module [ "C" ];
@@ -11,9 +18,9 @@ let no_prefix: Bundle.pat list ref = ref Bundle.[
 ]
 (* kremlib.h now added directly in Output.ml so that it appears before the first
  * #ifdef *)
-let add_include: (string option * string) list ref = ref [ ]
+let add_include: (include_ * string) list ref = ref [ ]
 let add_include_tmh = ref false
-let add_early_include: (string option * string) list ref = ref [ ]
+let add_early_include: (include_ * string) list ref = ref [ ]
 let warn_error = ref "+1..2@3+4..8@9+10@11+12..18@19+20..22"
 let tmpdir = ref "."
 let includes: string list ref = ref []

--- a/src/Output.ml
+++ b/src/Output.ml
@@ -9,10 +9,22 @@ open PPrint
 let mk_includes =
   separate_map hardline (fun x -> string "#include " ^^ string x)
 
-let filter_includes file includes =
+let filter_includes ~is_c file (includes: (Options.include_ * string) list) =
+  (* KPrint.bprintf "-- filter_includes for %s (%d)\n" file (List.length includes); *)
   KList.filter_some (List.rev_map (function
-    | Some file', h -> if file = file' then Some h else None
-    | None, h -> Some h
+    | Options.HeaderOnly file', h when file = file' ->
+        (* KPrint.bprintf "--- H Match %s: include %s\n" file h; *)
+        Some h
+    | COnly file', h when file = file' && is_c ->
+        (* KPrint.bprintf "--- C Match %s: include %s\n" file h; *)
+        Some h
+    | All, h ->
+        (* KPrint.bprintf "--- All Match %s: include %s\n" file h; *)
+        Some h
+    | _i, _h ->
+        (* KPrint.bprintf "--- No match for %s: -add-include %a:%s (is_c: %b)\n" *)
+        (*   file Options.pinc _i _h is_c; *)
+        None
   ) includes)
 
 let kremlib_include () =
@@ -25,8 +37,8 @@ let kremlib_include () =
  * - #include X for X in the dependencies of the file, followed by
  * - #include Y for each -add-include Y passed on the command-line
  *)
-let includes_for file files =
-  let extra_includes = mk_includes (filter_includes file !Options.add_include) in
+let includes_for ~is_c file files =
+  let extra_includes = mk_includes (filter_includes ~is_c file !Options.add_include) in
   let includes = mk_includes (List.rev_map (Printf.sprintf "\"%s.h\"") files) in
   separate hardline [ includes; extra_includes ]
 
@@ -71,12 +83,13 @@ let prefix_suffix original_name name =
     string "#endif" ^^ hardline
   in
   let macro_name = String.map (function '/' -> '_' | c -> c) name in
+  (* KPrint.bprintf "- add_early_includes: %s\n" original_name; *)
   let prefix =
     string (header ()) ^^ hardline ^^ hardline ^^
     string (Printf.sprintf "#ifndef __%s_H" macro_name) ^^ hardline ^^
     string (Printf.sprintf "#define __%s_H" macro_name) ^^ hardline ^^
     (if !Options.extern_c then hardline ^^ if_cpp (string "extern \"C\" {") ^^ hardline else empty) ^^
-    mk_includes (filter_includes original_name !Options.add_early_include) ^^ hardline ^^
+    mk_includes (filter_includes ~is_c:false original_name !Options.add_early_include) ^^ hardline ^^
     kremlib_include () ^^ hardline
   in
   let suffix =
@@ -120,7 +133,8 @@ let write_c files internal_headers deps =
     let deps = Bundles.StringMap.find name deps in
     let deps = List.of_seq (Bundles.StringSet.to_seq deps.Bundles.internal) in
     let deps = List.map (fun f -> "internal/" ^ f) deps in
-    let includes = hardline ^^ includes_for name deps ^^ hardline in
+    (* KPrint.bprintf "- write_c: %s\n" name; *)
+    let includes = hardline ^^ includes_for ~is_c:true name deps ^^ hardline in
     let header = header () in
     let internal = if Bundles.StringSet.mem name internal_headers then "internal/" else "" in
     (* If there is an internal header, we include that rather than the public
@@ -163,7 +177,8 @@ let write_h files public_headers deps =
       | C11.Public h ->
           name, h, public
     in
-    let includes = hardline ^^ includes_for original_name deps ^^ hardline in
+    (* KPrint.bprintf "- write_h: %s\n" name; *)
+    let includes = hardline ^^ includes_for ~is_c:false original_name deps ^^ hardline in
     let prefix, suffix = prefix_suffix original_name name in
     write_one (name ^ ".h") (prefix ^^ includes) program suffix;
     name

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,9 @@ BROKEN		= \
 # Lowlevel is not really broken, but its test shouldn't be run since it's a
 # special file and doesn't have a main.
 FILES		= \
-  $(patsubst %.fst,%.test,$(filter-out Unused_A.fst StaticHeaderAPI.fst StaticHeaderLib.fst NameCollisionHelper.fst ML16Externals.fst MemCpyModel.fst Lowlevel.fst $(BROKEN),$(wildcard *.fst))) \
+  $(patsubst %.fst,%.test,$(filter-out Unused_A.fst StaticHeaderAPI.fst \
+    StaticHeaderLib.fst NameCollisionHelper.fst ML16Externals.fst MemCpyModel.fst \
+    Lowlevel.fst PrivateInclude1.fst $(BROKEN),$(wildcard *.fst))) \
   $(CRYPTO)/Crypto.Symmetric.Chacha20.test \
   $(patsubst %.fst,%.test,$(wildcard ../book/*.fst ../book/notfslit/*.fst))
 
@@ -148,6 +150,7 @@ $(OUTPUT_DIR)/NameCollision.exe: EXTRA = -no-prefix NameCollisionHelper
 $(OUTPUT_DIR)/Intro.exe $(OUTPUT_DIR)/MemCpy.exe: EXTRA = -rst-snippets
 $(OUTPUT_DIR)/StaticHeader.exe: EXTRA = -static-header StaticHeaderLib -bundle StaticHeaderAPI=StaticHeaderLib -warn-error @7@8
 $(OUTPUT_DIR)/Unused_B.exe: EXTRA=-bundle Unused_A
+$(OUTPUT_DIR)/PrivateInclude2.exe: EXTRA=-no-prefix PrivateInclude1 -bundle PrivateInclude1 -add-include 'PrivateInclude1.c:"../../foobar.h"'
 
 Failure.test: NEGATIVE=true
 

--- a/test/PrivateInclude1.fst
+++ b/test/PrivateInclude1.fst
@@ -1,0 +1,6 @@
+module PrivateInclude1
+
+assume val foobar: FStar.Int32.t -> FStar.Int32.t
+
+let f () =
+  foobar 0l `FStar.Int32.add` 0l

--- a/test/PrivateInclude2.fst
+++ b/test/PrivateInclude2.fst
@@ -1,0 +1,5 @@
+module PrivateInclude2
+
+let foobar () = 0l
+
+let main () = foobar () `FStar.Int32.add` PrivateInclude1.f ()


### PR DESCRIPTION
This is useful to limit name collisions by not leaking un-namespaced function names to clients of a given module.

(Context: this came up in the context of Curve64, where Vale's un-namespaced `fadd` conflicts with `fadd` from the math library, making it impossible to write a client that uses both Curve64 and the original `fadd`.)

This fixes #182, also.