### PR TITLE
Remove side effect in driver mode

### DIFF
--- a/src/Driver.ml
+++ b/src/Driver.ml
@@ -263,7 +263,6 @@ let detect_fstar () =
   let fstar_includes = List.map expand_prefixes !Options.includes in
   fstar_options := [
     "--trace_error";
-    "--cache_checked_modules";
     "--expose_interfaces"
   ] @ List.flatten (List.rev_map (fun d -> ["--include"; d]) fstar_includes);
   (* This is a superset of the needed modules... some will be dropped very early


### PR DESCRIPTION
The use of `--cache_checked_modules` in the call to fstar triggers generation of `.checked.lax` files in all the included paths.
It appears unnecessary and can create issues, typically if a read-only path is included.