### PR TITLE
lib: add str as a dependency

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -16,6 +16,7 @@
   visitors.ppx
   visitors.runtime
   sedlex.ppx
+  str
   uucp)
  (preprocess
   (pps ppx_deriving.std ppx_deriving_yojson sedlex.ppx visitors.ppx))


### PR DESCRIPTION
I noticed in the Everest CI that, since yesterday, Karamel stopped building, with the following error:

```
gmake: Entering directory '/home/test/karamel'
dune build
gmake: Leaving directory '/home/test/karamel'
File "_none_", line 1:
Error: No implementations provided for the following modules:
Str referenced from lib/krml.cmxa(Krml__KString)
gmake: *** [Makefile:27: minimal] Error 1
```

This PR adds `str` as a dune dependency to resolve the missing module error.

I have seen no change in the Everest CI other than wasm being upgraded from 2.0.1 to 2.0.2. Perhaps Karamel should have failed to build already but somehow wasm 2.0.1 was providing undue cover; I did not dig further.
