### PR TITLE
Checker: fix check in EBufCreate case

### DIFF
--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -369,7 +369,8 @@ and check' env t e =
         Warn.(maybe_fatal_error (loc, Vla e))
       end;
       let t, _ = assert_buffer env t in
-      if t = TAny then
+      let t' = check_or_infer env t e1 in
+      if t' = TAny then
         checker_error env buf_any_msg ppexpr e;
       check env t e1;
       check_array_index env e2;

--- a/test/AllocFree.fst
+++ b/test/AllocFree.fst
@@ -1,0 +1,14 @@
+module AllocFree
+
+open FStar.HyperStack
+open FStar.HyperStack.ST
+
+let test1 () : Stack unit (fun _ -> False) (fun _ _ _ -> True) =
+  let b = FStar.Buffer.rcreate_mm root 1uL 999ul in
+  FStar.Buffer.rfree b
+
+let test2 () : Stack unit (fun _ -> False) (fun _ _ _ -> True) =
+  [@@CInline] let b = FStar.Buffer.rcreate_mm root 1uL 999ul in
+  FStar.Buffer.rfree b
+
+let main () = 0l


### PR DESCRIPTION
It's the actual type of the buffer elements, not the "goal" type received by check, that must not be TAny.

Fixes #644