### PR TITLE
Added Unsafe case for lvalue of EAssign in [safe_use]

### DIFF
--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -75,7 +75,7 @@ class ['self] safe_use lvalue = object (self: 'self)
   method! visit_EAssign ((j, _) as env) e1 e2 = 
     ignore (lvalue, j);
     match e1.node with 
-    (* | EBound i when i = j && not lvalue -> Unsafe *)
+    | EBound i when i = j && not lvalue -> Unsafe
     | _ -> self#unordered env [ e1; e2 ]
   method! visit_EApp env e es =
     match e.node with


### PR DESCRIPTION
This comes from https://github.com/AeneasVerif/eurydice/issues/338. According to discussions there and my understanding of this `safe_use` analyzer, I think we should mark the variable in a lvalue position as `Unsafe`. 