### PR TITLE
`internal/target.h`: Define `KRML_HOST_EPRINTF` for C++11 and up

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -46,8 +46,8 @@ typedef double float64_t;
 #  define KRML_HOST_PRINTF printf
 #endif
 
-#if (
-    ((defined(__cplusplus) && __cplusplus > 199711L) ||
+#if (                                                                   \
+    ((defined(__cplusplus) && __cplusplus > 199711L) ||                 \
      (defined __STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) &&    \
     (!(defined KRML_HOST_EPRINTF)))
 #  define KRML_HOST_EPRINTF(...) fprintf(stderr, __VA_ARGS__)


### PR DESCRIPTION
We use the macro like that e.g. in [libcrux](https://github.com/cryspen/libcrux/blob/57ef911f7aae2f8b92b2198aaddde634f422501a/libcrux-ml-kem/extracts/cpp_header_only/generated/karamel/target.h#L17) or in [libcrux-iot](https://github.com/AeneasVerif/eurydice/pull/354#issuecomment-3611468881).