### PR TITLE
CI: add EverParse CBOR, COSE regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,14 +138,6 @@ jobs:
     needs: build-deps
     runs-on: ubuntu-latest
     steps:
-      - name: Install Z3 with script
-        run: |
-          wget https://raw.githubusercontent.com/FStarLang/FStar/refs/heads/master/.scripts/get_fstar_z3.sh -O get_fstar_z3.sh
-          chmod +x get_fstar_z3.sh
-          ./get_fstar_z3.sh /usr/local/bin
-       # If these fail, stop right now.
-      - run: which z3-4.8.5
-      - run: which z3-4.13.3
 
       - name: Setup ocaml
         uses: ocaml/setup-ocaml@v3


### PR DESCRIPTION
Trying to answer Jonathan's question from https://github.com/FStarLang/karamel/pull/679#issuecomment-3893459478 :

> Would you like to add some additional regressions in the karamel CI? If so, I'm open to it

This PR augments Karamel's CI with an extraction test for EverCBOR and EverCOSE, the verified CBOR and COSE implementations from EverParse.

To this end, this PR adds a GitHub Actions job, `test-everparse`, into the existing CI workflow, to extract EverCBOR and EverCOSE. This job clearly isolates the calls to Karamel away from unrelated logs (e.g. F* verification and extraction to .krml)

`test-everparse` needs to build EverCBOR and EverCOSE, which by default takes ~ 18 minutes (see https://github.com/tahina-pro/karamel/actions/runs/22079451423/job/63801660122), but this PR introduces enough cache to reduce this task to a few seconds only (see https://github.com/tahina-pro/karamel/actions/runs/22083264582/job/63812690728)

Since `test-everparse` uses the same dependencies as `build-and-test-krml`, this PR also refactors the dependency build by adding a new prior job, `build-deps`, leveraging cache to be shared across the two jobs.

The 2 logs linked above succeed on EverParse because this PR has been initially built on top of the Karamel version used by EverParse as of 2/16/2026, fb36fecb552c9fb202beb38a6c5a732c3f2cd49f. They fail with Karamel master: in fact, this PR can be merged only after ~#679 is fixed and~ #681 is merged.