### PR TITLE
Add support for Pulse.Lib.Pervasives._zero_for_deref (PR to `master`)

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -856,6 +856,7 @@ and translate_expr_with_type (env: env) ?(context=`Other) (fn_t_ret: MiniRust.ty
   | EQualified lid ->
       begin try
         match lid with
+        | [ "Pulse"; "Lib"; "Pervasives" ], "_zero_for_deref"
         | [ "C" ], "_zero_for_deref" ->
             (* CInt for Rust means no suffix -- rustc will convert to usize or u32 *)
             env, Constant (CInt, "0")

--- a/lib/Builtin.ml
+++ b/lib/Builtin.ml
@@ -465,7 +465,7 @@ let prepare files =
      F* PR: References to module C can now occur even when the module is not in the scope.
      If so, we add the definition that is needed as a builtin, since it will be rewritten
      during C code generation *)
-  (if List.mem_assoc "C" files then [] else [c_deref]) @
+  (if List.mem_assoc "C" files || List.mem_assoc "Pulse_Lib_Pervasives" files then [] else [c_deref]) @
   (if List.mem_assoc "LowStar_Ignore" files then [] else [lowstar_ignore]) @
   []
 

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -960,6 +960,7 @@ and mk_stmts m stmts: C.stmt list =
 
 and mk_index m (e1: expr) (e2: expr): C.expr =
   match e2 with
+  | Qualified (["Pulse"; "Lib"; "Pervasives"], "_zero_for_deref")
   | Qualified (["C"], "_zero_for_deref") ->
       mk_deref m e1
   | _ ->

--- a/lib/Helpers.ml
+++ b/lib/Helpers.ml
@@ -497,6 +497,7 @@ let builtin_names =
     ["C"], "fflush";
     ["C"], "clock";
     (* Special array index to turn b[0] into *b (cf. PR #278) *)
+    ["Pulse"; "Lib"; "Pervasives"], "_zero_for_deref";
     ["C"], "_zero_for_deref";
     (* Hand-written type definition parameterized over KRML_VERIFIED_UINT128 *)
     ["FStar"; "UInt128"], "uint128";


### PR DESCRIPTION
This PR replicates #685 on `master`. (#685 was merged to a branch, `fstar2`, which we initially meant to use with F* branch `fstar2`, but we are now switching back to Karamel `master` instead, abandoning Karamel `fstar2` except for this change. Sorry @protz for the confusion!) 

As an alternative to C._zero_for_deref, in preparation for the deprecation of Low*.
