### PR TITLE
Fix UInt8/UInt16 comparison after wrapping arithmetic (#694)

### DIFF
--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -311,7 +311,8 @@ and mask w e =
 and is_integer_arith op w =
   w <> K.Bool && not (Constant.is_float w) && K.is_unsigned w && match op with
   | K.Add | AddW | Sub | SubW | Div | DivW | Mult | MultW | Mod
-  | BOr | BAnd | BXor | BShiftL | BShiftR | BNot ->
+  | BOr | BAnd | BXor | BShiftL | BShiftR | BNot
+  | Eq | Neq | Lt | Lte | Gt | Gte ->
       true
   | _ ->
       false
@@ -342,6 +343,8 @@ and mk_arith env e =
           CStar.Call (Op op, [ mask_if a1 w e1; mask_if a2 w e2 ])
       | BShiftR ->
           CStar.Call (Op op, [ mask_if a1 w e1; e2 ])
+      | Eq | Neq | Lt | Lte | Gt | Gte ->
+          CStar.Call (Op op, [ mask_if a1 w e1; mask_if a2 w e2 ])
       | _ ->
           assert false
       end, false, w1 || w2

--- a/test/SmallIntPromotion.fst
+++ b/test/SmallIntPromotion.fst
@@ -1,0 +1,27 @@
+/// Regression test for karamel issue #694.
+/// Tests that UInt8/UInt16 integer promotion correctly masks results
+/// before comparisons.
+module SmallIntPromotion
+
+open FStar.UInt8
+
+/// Comparison after wrapping arithmetic must mask to 8 bits.
+/// Use runtime parameters to prevent constant folding.
+let check_add_compare (a b c: UInt8.t) : bool = (a +%^ b) = c
+let check_sub_compare (a b c: UInt8.t) : bool = (a -%^ b) = c
+let check_add_lt (a b c: UInt8.t) : bool = (a +%^ b) <^ c
+let check_shl_compare (a: UInt8.t) (s: FStar.UInt32.t{FStar.UInt32.v s < 8}) (c: UInt8.t) : bool =
+  (a <<^ s) = c
+
+/// Comparison in if-condition must also mask.
+let check_if_add (a b c: UInt8.t) : FStar.Int32.t =
+  if (a +%^ b) = c then 0l else 1l
+
+let main () : FStar.Int32.t =
+  if check_add_compare 255uy 2uy 1uy
+  && check_sub_compare 0uy 1uy 255uy
+  && check_add_lt 200uy 100uy 50uy
+  && check_shl_compare 0x80uy 1ul 0uy
+  && check_if_add 255uy 2uy 1uy = 0l
+  then 0l
+  else 1l


### PR DESCRIPTION
Comparisons (Eq, Neq, Lt, Lte, Gt, Gte) on UInt8/UInt16 after wrapping arithmetic (add_mod, sub_mod, mul_mod, shift_left, xor, or, etc.) produced wrong C code. The uint32 intermediate from mk_arith was compared directly without masking back to the original width.

For example, (255uy +%^ 1uy) = 0uy generated:
  (uint32_t)255 + (uint32_t)1 == 0  =>  256 == 0  =>  false (WRONG)

Fix: add comparison operators to is_integer_arith so they enter mk_arith, and mask both operands before comparing (same strategy as Div/Mod).

Now generates:
  ((uint32_t)255 + (uint32_t)1 & 0xFFU) == (uint32_t)0  =>  0 == 0  =>  true

Fixes #694. Also fixes #689, #691, #692, #693 (same root cause).