### PR TITLE
Fix `FStar_UInt128_lognot`: MSVC SSE2 path always returns zero

### DIFF
--- a/krmllib/c/fstar_uint128_msvc.h
+++ b/krmllib/c/fstar_uint128_msvc.h
@@ -204,7 +204,7 @@ FStar_UInt128_logor(FStar_UInt128_uint128 a, FStar_UInt128_uint128 b) {
 
 inline static FStar_UInt128_uint128 FStar_UInt128_lognot(FStar_UInt128_uint128 a) {
 #if HAS_OPTIMIZED
-  return _mm_andnot_si128(a, a);
+  return _mm_xor_si128(a, _mm_set_epi64x(-1LL, -1LL));
 #else
   FStar_UInt128_uint128 lit;
   lit.low = ~a.low;

--- a/krmllib/dist/generic/fstar_uint128_msvc.h
+++ b/krmllib/dist/generic/fstar_uint128_msvc.h
@@ -204,7 +204,7 @@ FStar_UInt128_logor(FStar_UInt128_uint128 a, FStar_UInt128_uint128 b) {
 
 inline static FStar_UInt128_uint128 FStar_UInt128_lognot(FStar_UInt128_uint128 a) {
 #if HAS_OPTIMIZED
-  return _mm_andnot_si128(a, a);
+  return _mm_xor_si128(a, _mm_set_epi64x(-1LL, -1LL));
 #else
   FStar_UInt128_uint128 lit;
   lit.low = ~a.low;

--- a/krmllib/dist/minimal/fstar_uint128_msvc.h
+++ b/krmllib/dist/minimal/fstar_uint128_msvc.h
@@ -204,7 +204,7 @@ FStar_UInt128_logor(FStar_UInt128_uint128 a, FStar_UInt128_uint128 b) {
 
 inline static FStar_UInt128_uint128 FStar_UInt128_lognot(FStar_UInt128_uint128 a) {
 #if HAS_OPTIMIZED
-  return _mm_andnot_si128(a, a);
+  return _mm_xor_si128(a, _mm_set_epi64x(-1LL, -1LL));
 #else
   FStar_UInt128_uint128 lit;
   lit.low = ~a.low;


### PR DESCRIPTION
`FStar_UInt128_lognot` in the MSVC uint128 header uses `_mm_andnot_si128(a, a)` to compute the bitwise complement. This is wrong. The Intel intrinsic `_mm_andnot_si128(a, b)` computes `(~a) & b`, so `_mm_andnot_si128(a, a)` computes `(~a) & a`, which is identically zero for all inputs.

Any caller of `FStar.UInt128.lognot` on MSVC x64 with SSE2 (i.e. when `HAS_OPTIMIZED` is 1) silently gets zero instead of the bitwise complement. The non-optimized `#else` fallback (`~a.low` / `~a.high`) is correct.

This affects any code that calls `FStar.UInt128.lognot` when compiled with MSVC on x64, which is the standard Windows 64-bit build configuration. Cryptographic uses of `lognot` on 128-bit integers (e.g. constant-time masking in Curve25519, Poly1305, or similar primitives) would silently produce wrong results: the mask would be zero instead of the expected complement, potentially leaking secrets or corrupting output.

This fix replaces the incorrect implementation with `_mm_xor_si128(a, _mm_set_epi64x(-1LL, -1LL))`, which computes `a ^ 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` = `~a`.