### PR TITLE
Add constant folding for booleans

### DIFF
--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -507,6 +507,35 @@ let constant_fold = object (self)
         | _ -> EApp (e, [ e1; e2 ])
     )
 
+    | EOp (K.And, _), [e1; e2] -> (
+        let e1 = self#visit_expr env e1 in
+        let e2 = self#visit_expr env e2 in
+        match e1.node, e2.node with
+        | EBool false, _ -> EBool false
+        | _, EBool false -> EBool false
+        | EBool true, e2 -> e2
+        | e1, EBool true -> e1
+        | _ -> EApp (e, [e1; e2])
+    )
+
+    | EOp (K.Or, _), [e1; e2] -> (
+        let e1 = self#visit_expr env e1 in
+        let e2 = self#visit_expr env e2 in
+        match e1.node, e2.node with
+        | EBool true, _ -> EBool true
+        | _, EBool true -> EBool true
+        | EBool false, e2 -> e2
+        | e1, EBool false -> e1
+        | _ -> EApp (e, [e1;e2 ])
+    )
+
+    | EOp (K.Not, _), [e1] -> (
+        let e1 = self#visit_expr env e1 in
+        match e1.node with
+        | EBool b -> EBool (not b)
+        | _ -> EApp (e, [e1])
+    )
+
     | _ ->
         EApp (self#visit_expr env e, List.map (self#visit_expr env) es)
 end

--- a/test/pulse/BoolFold.expected.c
+++ b/test/pulse/BoolFold.expected.c
@@ -1,0 +1,17 @@
+/* krml header omitted for test repeatability */
+
+
+#include "BoolFold.h"
+
+void BoolFold_main(void)
+{
+  BoolFold_f(true);
+  BoolFold_f(false);
+  BoolFold_f(true);
+  BoolFold_f(true);
+  BoolFold_f(false);
+  BoolFold_f(false);
+  BoolFold_f(true);
+  BoolFold_f(false);
+}
+

--- a/test/pulse/BoolFold.fst
+++ b/test/pulse/BoolFold.fst
@@ -1,0 +1,17 @@
+module BoolFold
+
+assume
+val f : bool -> Dv unit
+
+let main () =
+  [@@CInline] let x = true in
+  [@@CInline] let y = true in
+  f (x && y);
+  f (x && not y);
+  f (x || y);
+  f (x || not y);
+  f (not x && y);
+  f (not x && not y);
+  f (not x || y);
+  f (not x || not y);
+  ()


### PR DESCRIPTION
We sometimes generate trivial boolean expressions after inlining. This patch makes them simplify. A test is added.

Example output before:

	void BoolFold_main(void)
	{
	  BoolFold_f(true && true);
	  BoolFold_f(true && !true);
	  BoolFold_f(true || true);
	  BoolFold_f(true || !true);
	  BoolFold_f(!true && true);
	  BoolFold_f(!true && !true);
	  BoolFold_f(!true || true);
	  BoolFold_f(!true || !true);
	}

After:

	void BoolFold_main(void)
	{
	  BoolFold_f(true);
	  BoolFold_f(false);
	  BoolFold_f(true);
	  BoolFold_f(true);
	  BoolFold_f(false);
	  BoolFold_f(false);
	  BoolFold_f(true);
	  BoolFold_f(false);
	}

This does not generate a diff in krmllib dist.

--

Hi Jonathan. At a high level I wonder if you agree that beefing up these simplification passes is worth it to generate higher-quality code, since it is of course more TCB. Happy to gate this via an option if you think that's better. See also upcoming PR on ternary operator.