### PR TITLE
CI: do not share OPAM switch cache between fstar1 and fstar2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
           key: opam-${{ runner.os }}-${{ runner.arch }}-fstar1-${{ github.run_id }}
           restore-keys: |
             opam-${{ runner.os }}-${{ runner.arch }}-fstar1-
-            opam-${{ runner.os }}-${{ runner.arch }}-
 
       # Build F*, from the fstar1 branch.
       - run: opam update
@@ -254,17 +253,14 @@ jobs:
         with:
            ocaml-compiler: 5.3.0
 
-      # Note, we prefer to restore the -master cache, but if it doesn't exist,
-      # we restore the latest normal one.
+      # Note, this cache is separate from the -fstar1 one.
       - name: Restore OPAM state
         uses: actions/cache/restore@v4
         with:
-          fail-on-cache-miss: true
           path: _opam
           key: opam-${{ runner.os }}-${{ runner.arch }}-master-${{ github.run_id }}
           restore-keys: |
             opam-${{ runner.os }}-${{ runner.arch }}-master-
-            opam-${{ runner.os }}-${{ runner.arch }}-
 
       # Build F*, master branch
       - run: opam update


### PR DESCRIPTION
I think this is causing failures when trying to re-run a workflow. The build-deps job restores a cache with F* master, pins F* to fstar1, and then installing F* fails with:
```
[ERROR] No definition found for the following installed packages: { fstar.2026.04.17~dev }
        This switch may need to be reinstalled

<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
[fstar.2026.03.24~dev] synchronised (no changes)

[ERROR] No opam file found for fstar.2026.04.17~dev
The following actions will be performed:
Fatal error:
Not_found
Error: Process completed with exit code 99.
```
See https://github.com/FStarLang/karamel/actions/runs/25078028296/job/73728388857

The gains from sharing the cache are marginal anyway. Just keep them separate.