### PR TITLE
-fternary: Support generating C's ternary operator (?:)

### DIFF
--- a/krmllib/dist/generic/FStar_Attributes.c
+++ b/krmllib/dist/generic/FStar_Attributes.c
@@ -11,14 +11,7 @@ FStar_Attributes_uu___is_PpxDerivingShow(
   FStar_Attributes___internal_ocaml_attributes projectee
 )
 {
-  if (projectee.tag == FStar_Attributes_PpxDerivingShow)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_PpxDerivingShow;
 }
 
 bool
@@ -26,14 +19,7 @@ FStar_Attributes_uu___is_PpxDerivingShowConstant(
   FStar_Attributes___internal_ocaml_attributes projectee
 )
 {
-  if (projectee.tag == FStar_Attributes_PpxDerivingShowConstant)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_PpxDerivingShowConstant;
 }
 
 bool
@@ -41,111 +27,48 @@ FStar_Attributes_uu___is_PpxDerivingYoJson(
   FStar_Attributes___internal_ocaml_attributes projectee
 )
 {
-  if (projectee.tag == FStar_Attributes_PpxDerivingYoJson)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_PpxDerivingYoJson;
 }
 
 bool FStar_Attributes_uu___is_CInline(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CInline)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CInline;
 }
 
 bool
 FStar_Attributes_uu___is_Substitute(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_Substitute)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_Substitute;
 }
 
 bool FStar_Attributes_uu___is_Gc(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_Gc)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_Gc;
 }
 
 bool FStar_Attributes_uu___is_Comment(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_Comment)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_Comment;
 }
 
 bool FStar_Attributes_uu___is_CPrologue(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CPrologue)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CPrologue;
 }
 
 bool FStar_Attributes_uu___is_CEpilogue(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CEpilogue)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CEpilogue;
 }
 
 bool FStar_Attributes_uu___is_CConst(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CConst)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CConst;
 }
 
 bool FStar_Attributes_uu___is_CCConv(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CCConv)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CCConv;
 }
 
 bool
@@ -153,49 +76,21 @@ FStar_Attributes_uu___is_CAbstractStruct(
   FStar_Attributes___internal_ocaml_attributes projectee
 )
 {
-  if (projectee.tag == FStar_Attributes_CAbstractStruct)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CAbstractStruct;
 }
 
 bool FStar_Attributes_uu___is_CIfDef(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CIfDef)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CIfDef;
 }
 
 bool FStar_Attributes_uu___is_CMacro(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CMacro)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CMacro;
 }
 
 bool FStar_Attributes_uu___is_CNoInline(FStar_Attributes___internal_ocaml_attributes projectee)
 {
-  if (projectee.tag == FStar_Attributes_CNoInline)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_CNoInline;
 }
 

--- a/krmllib/dist/generic/FStar_NormSteps.c
+++ b/krmllib/dist/generic/FStar_NormSteps.c
@@ -10,230 +10,97 @@
 
 bool FStar_NormSteps_uu___is_Simpl(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Simpl)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Simpl;
 }
 
 bool FStar_NormSteps_uu___is_Weak(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Weak)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Weak;
 }
 
 bool FStar_NormSteps_uu___is_HNF(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_HNF)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_HNF;
 }
 
 bool FStar_NormSteps_uu___is_Primops(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Primops)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Primops;
 }
 
 bool FStar_NormSteps_uu___is_Delta(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Delta)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Delta;
 }
 
 bool FStar_NormSteps_uu___is_Zeta(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Zeta)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Zeta;
 }
 
 bool FStar_NormSteps_uu___is_ZetaFull(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_ZetaFull)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_ZetaFull;
 }
 
 bool FStar_NormSteps_uu___is_Iota(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Iota)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Iota;
 }
 
 bool FStar_NormSteps_uu___is_NBE(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_NBE)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_NBE;
 }
 
 bool FStar_NormSteps_uu___is_Reify(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Reify)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Reify;
 }
 
 bool FStar_NormSteps_uu___is_NormDebug(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_NormDebug)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_NormDebug;
 }
 
 bool FStar_NormSteps_uu___is_UnfoldOnly(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_UnfoldOnly)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_UnfoldOnly;
 }
 
 bool FStar_NormSteps_uu___is_UnfoldOnce(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_UnfoldOnce)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_UnfoldOnce;
 }
 
 bool FStar_NormSteps_uu___is_UnfoldFully(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_UnfoldFully)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_UnfoldFully;
 }
 
 bool FStar_NormSteps_uu___is_UnfoldAttr(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_UnfoldAttr)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_UnfoldAttr;
 }
 
 bool FStar_NormSteps_uu___is_UnfoldQual(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_UnfoldQual)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_UnfoldQual;
 }
 
 bool FStar_NormSteps_uu___is_UnfoldNamespace(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_UnfoldNamespace)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_UnfoldNamespace;
 }
 
 bool FStar_NormSteps_uu___is_Unmeta(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Unmeta)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Unmeta;
 }
 
 bool FStar_NormSteps_uu___is_Unascribe(FStar_NormSteps_norm_step projectee)
 {
-  if (projectee.tag == FStar_NormSteps_Unascribe)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_NormSteps_Unascribe;
 }
 
 FStar_NormSteps_norm_step FStar_NormSteps_simplify = { .tag = FStar_NormSteps_Simpl };

--- a/krmllib/dist/generic/FStar_Order.c
+++ b/krmllib/dist/generic/FStar_Order.c
@@ -113,13 +113,9 @@ FStar_Order_order FStar_Order_order_from_int(krml_checked_int_t i)
   {
     return FStar_Order_Lt;
   }
-  else if (i == (krml_checked_int_t)0)
-  {
-    return FStar_Order_Eq;
-  }
   else
   {
-    return FStar_Order_Gt;
+    return i == (krml_checked_int_t)0 ? FStar_Order_Eq : FStar_Order_Gt;
   }
 }
 

--- a/krmllib/dist/generic/FStar_UInt128_Verified.h
+++ b/krmllib/dist/generic/FStar_UInt128_Verified.h
@@ -159,14 +159,9 @@ FStar_UInt128_shift_left_large(FStar_UInt128_uint128 a, uint32_t s)
 static inline FStar_UInt128_uint128
 FStar_UInt128_shift_left(FStar_UInt128_uint128 a, uint32_t s)
 {
-  if (s < FStar_UInt128_u32_64)
-  {
-    return FStar_UInt128_shift_left_small(a, s);
-  }
-  else
-  {
-    return FStar_UInt128_shift_left_large(a, s);
-  }
+  return
+    s < FStar_UInt128_u32_64 ? FStar_UInt128_shift_left_small(a, s)
+                             : FStar_UInt128_shift_left_large(a, s);
 }
 
 static inline uint64_t FStar_UInt128_add_u64_shift_right(uint64_t hi, uint64_t lo, uint32_t s)
@@ -208,14 +203,9 @@ FStar_UInt128_shift_right_large(FStar_UInt128_uint128 a, uint32_t s)
 static inline FStar_UInt128_uint128
 FStar_UInt128_shift_right(FStar_UInt128_uint128 a, uint32_t s)
 {
-  if (s < FStar_UInt128_u32_64)
-  {
-    return FStar_UInt128_shift_right_small(a, s);
-  }
-  else
-  {
-    return FStar_UInt128_shift_right_large(a, s);
-  }
+  return
+    s < FStar_UInt128_u32_64 ? FStar_UInt128_shift_right_small(a, s)
+                             : FStar_UInt128_shift_right_large(a, s);
 }
 
 static inline bool FStar_UInt128_eq(FStar_UInt128_uint128 a, FStar_UInt128_uint128 b)

--- a/krmllib/dist/generic/WasmSupport.c
+++ b/krmllib/dist/generic/WasmSupport.c
@@ -8,14 +8,7 @@
 
 uint32_t WasmSupport_align_64(uint32_t x)
 {
-  if (!((x & 0x07U) == 0U))
-  {
-    return (x & 4294967288U) + 0x08U;
-  }
-  else
-  {
-    return x;
-  }
+  return !((x & 0x07U) == 0U) ? (x & 4294967288U) + 0x08U : x;
 }
 
 void WasmSupport_check_buffer_size(uint32_t s)

--- a/krmllib/dist/minimal/FStar_UInt128_Verified.h
+++ b/krmllib/dist/minimal/FStar_UInt128_Verified.h
@@ -159,14 +159,9 @@ FStar_UInt128_shift_left_large(FStar_UInt128_uint128 a, uint32_t s)
 static inline FStar_UInt128_uint128
 FStar_UInt128_shift_left(FStar_UInt128_uint128 a, uint32_t s)
 {
-  if (s < FStar_UInt128_u32_64)
-  {
-    return FStar_UInt128_shift_left_small(a, s);
-  }
-  else
-  {
-    return FStar_UInt128_shift_left_large(a, s);
-  }
+  return
+    s < FStar_UInt128_u32_64 ? FStar_UInt128_shift_left_small(a, s)
+                             : FStar_UInt128_shift_left_large(a, s);
 }
 
 static inline uint64_t FStar_UInt128_add_u64_shift_right(uint64_t hi, uint64_t lo, uint32_t s)
@@ -208,14 +203,9 @@ FStar_UInt128_shift_right_large(FStar_UInt128_uint128 a, uint32_t s)
 static inline FStar_UInt128_uint128
 FStar_UInt128_shift_right(FStar_UInt128_uint128 a, uint32_t s)
 {
-  if (s < FStar_UInt128_u32_64)
-  {
-    return FStar_UInt128_shift_right_small(a, s);
-  }
-  else
-  {
-    return FStar_UInt128_shift_right_large(a, s);
-  }
+  return
+    s < FStar_UInt128_u32_64 ? FStar_UInt128_shift_right_small(a, s)
+                             : FStar_UInt128_shift_right_large(a, s);
 }
 
 static inline bool FStar_UInt128_eq(FStar_UInt128_uint128 a, FStar_UInt128_uint128 b)

--- a/krmllib/dist/uint128/FStar_UInt128_Verified.h
+++ b/krmllib/dist/uint128/FStar_UInt128_Verified.h
@@ -159,14 +159,9 @@ FStar_UInt128_shift_left_large(FStar_UInt128_uint128 a, uint32_t s)
 static inline FStar_UInt128_uint128
 FStar_UInt128_shift_left(FStar_UInt128_uint128 a, uint32_t s)
 {
-  if (s < FStar_UInt128_u32_64)
-  {
-    return FStar_UInt128_shift_left_small(a, s);
-  }
-  else
-  {
-    return FStar_UInt128_shift_left_large(a, s);
-  }
+  return
+    s < FStar_UInt128_u32_64 ? FStar_UInt128_shift_left_small(a, s)
+                             : FStar_UInt128_shift_left_large(a, s);
 }
 
 static inline uint64_t FStar_UInt128_add_u64_shift_right(uint64_t hi, uint64_t lo, uint32_t s)
@@ -208,14 +203,9 @@ FStar_UInt128_shift_right_large(FStar_UInt128_uint128 a, uint32_t s)
 static inline FStar_UInt128_uint128
 FStar_UInt128_shift_right(FStar_UInt128_uint128 a, uint32_t s)
 {
-  if (s < FStar_UInt128_u32_64)
-  {
-    return FStar_UInt128_shift_right_small(a, s);
-  }
-  else
-  {
-    return FStar_UInt128_shift_right_large(a, s);
-  }
+  return
+    s < FStar_UInt128_u32_64 ? FStar_UInt128_shift_right_small(a, s)
+                             : FStar_UInt128_shift_right_large(a, s);
 }
 
 static inline bool FStar_UInt128_eq(FStar_UInt128_uint128 a, FStar_UInt128_uint128 b)

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -294,6 +294,7 @@ type expr' =
   | ECast of expr * typ_wo
   | EStandaloneComment of string
   | EAddrOf of expr
+  | ETernary of expr * expr * expr
 
   [@@deriving show,
     visitors { variety = "map"; ancestors = [ "map_typ_adapter" ]; name = "map_expr" },

--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -1003,6 +1003,9 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
   | EBufNull ->
       locals, CF.Constant (K.UInt32, "0")
 
+  | ETernary (e1, e2, e3) ->
+      (* No need for ternary in CFlat, turn to if-then-else and recurse *)
+      mk_expr env locals (with_type e.typ (EIfThenElse (e1, e2, e3)))
 
 (* See digression for [dup32] in CFlatToWasm *)
 let scratch_locals =

--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -480,6 +480,9 @@ and mk_expr env in_stmt under_initializer_list e =
   | EBufNull ->
       CStar.BufNull
 
+  | ETernary (e1, e2, e3) ->
+      CStar.Ternary (mk_expr env false e1, mk_expr env false e2, mk_expr env false e3)
+
   | _ ->
       Warn.maybe_fatal_error (KPrint.bsprintf "%a" Loc.ploc env.location, NotLowStar e);
       CStar.Any
@@ -726,6 +729,9 @@ and mk_stmts env e ret_type =
 
     | _ when return_pos <> Not ->
         mk_as_return env e (comment e.meta @ acc) return_pos
+
+    | ETernary _ ->
+      Warn.fatal_error "ETernary in stmt position?: %a\n" pexpr e
 
     | _ ->
         (* This is a specialized instance of `mk_as_return` when return_pos = Not *)

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1352,6 +1352,10 @@ and translate_expr_with_type (env: env) ?(context=`Other) (fn_t_ret: MiniRust.ty
         (* POSSIBLE FIX (if we care): insert slice::from_ref, since the expected
            Rust type for this is a slice (and maybe ditch possibly_convert) *)
 
+  | ETernary (e1, e2, e3) ->
+      (* Rust has if-then-else expressions, go back to it and keep going. *)
+      translate_expr_with_type env ~context fn_t_ret (Ast.with_type e.typ (Ast.EIfThenElse (e1, e2, e3))) t_ret
+
 and translate_pat env (p: Ast.pattern): MiniRust.pat =
   match p.node with
   | PBound v -> VarP v

--- a/lib/C11.ml
+++ b/lib/C11.ml
@@ -70,7 +70,7 @@ and expr =
   (* Not in the C grammar either; encode a C++ initializer list that appears in expression position
      so as to rely on an implicit constructor *)
   | CxxInitializerList of init
-    
+  | Ternary of expr * expr * expr
 
 (** this is a WILD approximation of the notion of "type name" in C _and_ a hack
  * because there's the invariant that the ident found at the bottom of the

--- a/lib/CStar.ml
+++ b/lib/CStar.ml
@@ -85,6 +85,7 @@ and expr =
         therefore are more closely modeled as an expression, but truly may
         contain anything as arguments, including statements. *)
   | Type of typ
+  | Ternary of expr * expr * expr
   [@@deriving show]
 
 and block =

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -100,6 +100,8 @@ let rec vars_of m = function
       KList.reduce S.union (List.map (fun (_, e) -> vars_of m e) fieldexprs)
   | Stmt stmts ->
       vars_of_block m stmts
+  | Ternary (e1, e2, e3) ->
+      S.union (vars_of m e1) (S.union (vars_of m e2) (vars_of m e3))
 
 and vars_of_block m stmts =
   KList.reduce S.union (List.map (vars_of_stmt m) stmts)
@@ -680,6 +682,9 @@ and mk_stmt m (stmt: stmt): C.stmt list =
           | Any ->
             true
 
+          | Ternary (c, t, e) ->
+            is_pure c && is_pure t && is_pure e
+
           (* Calls in general we take as impure, but operators
              are pure. *)
           | Call (Op _, args) -> List.for_all is_pure args
@@ -1153,6 +1158,8 @@ and mk_expr m (e: expr): C.expr =
   | Type t ->
       Type (mk_type m t)
 
+  | Ternary (c, t, e) ->
+      Ternary (mk_expr m c, mk_expr m t, mk_expr m e)
 
 and mk_compound_literal m name fields =
   let name = to_c_name m (name, Type) in

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -506,6 +506,10 @@ and check' env t e =
   | EAddrOf e ->
       check env (assert_tbuf t) e
 
+  | ETernary (c, th, el) ->
+      check env TBool c;
+      check env t th;
+      check env t el
 
 and check_case env c t =
   match c, t with
@@ -880,6 +884,13 @@ and infer' env e =
       assert (e.typ <> TAny);
       (* e.typ is the type of the whole node, so it's already of the form TBuf _ *)
       e.typ
+
+  | ETernary (c, t, e) ->
+      check env TBool c;
+      let t1 = infer env t in
+      let t2 = infer env e in
+      check_eqtype env t1 t2;
+      t1
 
 and infer_and_check_eq: 'a. env -> ('a -> typ) -> 'a list -> typ =
   fun env f l ->

--- a/lib/PrintAst.ml
+++ b/lib/PrintAst.ml
@@ -369,6 +369,12 @@ and print_expr env { node; typ; meta } =
       string "NULL" ^^ langle ^^ print_typ typ ^^ rangle
   | EContinue ->
       string "continue"
+  | ETernary (c, t, e) ->
+      parens_with_nesting (
+        print_expr env c ^/^
+          string "?" ^/^ print_expr env t ^/^
+          string ":" ^/^ print_expr env e
+      )
 
 and print_poly_comp = function
   | PEq -> equals

--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -344,6 +344,16 @@ and p_expr' curr = function
       p_stmts stmts
   | CxxInitializerList init ->
       p_init init
+  | Ternary (c, t, e) ->
+      let mine = 13 in
+      let c = p_expr' 12 c in
+      (* "The expression in the middle of the conditional operator (between ?
+      and :) is parsed as if parenthesized: its precedence relative to ?: is
+      ignored." Hence the 15 (max) here. *)
+      let t = p_expr' 15 t in
+      let e = p_expr' 13 e in
+      paren_if curr mine @@
+      group c ^^ space ^^ align (qmark ^^ space ^^ group t ^/^ colon ^^ space ^^ group e)
 
 (* statement-level comment *)
 and p_comment s =

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -526,7 +526,7 @@ let constant_fold = object (self)
         | _, EBool true -> EBool true
         | EBool false, e2 -> e2
         | e1, EBool false -> e1
-        | _ -> EApp (e, [e1;e2 ])
+        | _ -> EApp (e, [e1; e2])
     )
 
     | EOp (K.Not, _), [e1] -> (
@@ -538,6 +538,44 @@ let constant_fold = object (self)
 
     | _ ->
         EApp (self#visit_expr env e, List.map (self#visit_expr env) es)
+
+  method! visit_ETernary env c t e =
+    let c = self#visit_expr env c in
+    let t = self#visit_expr env t in
+    let e = self#visit_expr env e in
+    assert (c.typ = TBool);
+    (* Some of the rules below are gated with type information, to make sure we
+    don't end up rewriting something like `p ? true : 42` into `p || 42`, which
+    would booleanize the 42 into 1. Karamel's typechecker should prevent this
+    from being the case (the types of the branches should match and be either
+    TBool or TInt), but better safe than sorry. *)
+    match c.node, t.node, e.node with
+    | EBool true, _, _ ->
+      (* true ? t : e  ~>  t *)
+      t.node
+    | EBool false, _, _ ->
+      (* false ? t : e  ~>  e *)
+      e.node
+    | _, EBool false, EBool true ->
+      (* c ? false : true  ~>  !c *)
+      (mk_not c).node
+    | _, EBool true, EBool false ->
+      (* c ? true : false  ~>  c. Note, we know that c is TBool. *)
+      c.node
+    | _, EBool true, _ when e.typ = TBool ->
+      (* c ? true : e  ~>  c || e *)
+      (mk_or c e).node
+    | _, EBool false, _ when e.typ = TBool ->
+      (* c ? false : e  ~>  !c && e *)
+      (mk_and (mk_not c) e).node
+    | _, _, EBool true when t.typ = TBool ->
+      (* c ? t : true  ~>  !c || t *)
+      (mk_or (mk_not c) t).node
+    | _, _, EBool false when t.typ = TBool ->
+      (* c ? t : false  ~>  c && t *)
+      (mk_and c t).node
+    | _ ->
+      ETernary (c, t, e)
 end
 
 let remove_ignore_unit = object
@@ -672,6 +710,40 @@ let let_if_to_assign = object (self)
 
     | _ ->
         EAssign (e1, e2)
+end
+
+(* Check if an expression references any ifdef variable. If so, we must keep it
+   as EIfThenElse so that AstToCStar can compile it to #ifdef. *)
+let references_ifdef ifdefs =
+  (object
+    inherit [_] reduce
+    method private zero = false
+    method private plus = (||)
+    method! visit_EQualified _ lid = Idents.LidSet.mem lid ifdefs
+  end)#visit_expr_w ()
+
+(* Eligible for use inside a C ternary: readonly (no side effects, no function
+   calls) AND no statement constructs (ELet, EIfThenElse) anywhere in the
+   subtree. *)
+let is_ternary_eligible = (object
+  inherit [_] readonly_visitor
+  method! visit_ELet _ _ _ _ = false
+  method! visit_EIfThenElse _ _ _ _ = false
+end)#visit_expr_w ()
+
+let use_ternary_op ifdefs = object (self)
+  inherit [_] map
+
+  method! visit_EIfThenElse env c t e =
+    let c = self#visit_expr env c in
+    let t = self#visit_expr env t in
+    let e = self#visit_expr env e in
+    if is_ternary_eligible c &&
+       is_ternary_eligible t &&
+       is_ternary_eligible e &&
+       not (references_ifdef ifdefs c)
+    then ETernary (c, t, e)
+    else EIfThenElse (c, t, e)
 end
 
 (* Transform functional updates of the form x.(i) <- { x.(i) with f = e } into
@@ -1565,6 +1637,14 @@ and hoist_expr tbl loc pos e =
       else
         Warn.fatal_error "%a: %s" Loc.ploc loc "[continue] expressions should only appear in statement position"
 
+  | ETernary (e1, e2, e3) ->
+      let lhs1, e1 = hoist_expr loc Unspecified e1 in
+      let lhs2, e2 = hoist_expr loc UnderConditional e2 in
+      let e2 = nest lhs2 e2.typ e2 in
+      let lhs3, e3 = hoist_expr loc UnderConditional e3 in
+      let e3 = nest lhs3 e3.typ e3 in
+      lhs1, mk (ETernary (e1, e2, e3))
+
 (* TODO: figure out if we want to ignore the other cases for performance
  * reasons. *)
 class hoist = object
@@ -2265,6 +2345,7 @@ let simplify2 ifdefs (files: file list): file list =
   (* Quality of hoisting is WIDELY improved if we remove un-necessary
    * let-bindings. Also removes occurrences of spinlock and the like. *)
   let files = optimize_lets ~ifdefs files in
+  let files = (use_ternary_op ifdefs)#visit_files () files in
   let files = if Options.wasm () then files else fixup_while_tests#visit_files () files in
   let files = (new hoist)#visit_files [] files in
   let files = if !Options.c89_scope then SimplifyC89.hoist_lets#visit_files (ref []) files else files in

--- a/lib/SimplifyMerge.ml
+++ b/lib/SimplifyMerge.ml
@@ -311,6 +311,12 @@ let rec merge' (env: env) (u: S.t) (e: expr): S.t * S.t * expr =
       let d, u, e = merge env u e in
       d, u, w (EAddrOf e)
 
+  | ETernary (e1, e2, e3) ->
+      let d2, u2, e2 = merge env u e2 in
+      let d3, u3, e3 = merge env u e3 in
+      let d1, u, e1 = merge env (S.union u2 u3) e1 in
+      S.inter (S.inter d1 d2) d3, u, w (ETernary (e1, e2, e3))
+
 and merge (env: env) (u: S.t) (e: expr): S.t * S.t * expr =
   let d, u, e = merge' env u e in
   if debug then

--- a/lib/Structs.ml
+++ b/lib/Structs.ml
@@ -701,6 +701,9 @@ let to_addr is_struct =
     | EIfThenElse (e1, e2, e3) ->
         w (EIfThenElse (to_addr false e1, to_addr false e2, to_addr false e3))
 
+    | ETernary (e1, e2, e3) ->
+        w (ETernary (to_addr false e1, to_addr false e2, to_addr false e3))
+
     | EAssign (e1, e2) ->
         (* In the case of a by-copy struct assignment (for the return value of
          * an if-then-else, for instance), we do not recurse. This is morally an

--- a/test/pulse/Break.expected.c
+++ b/test/pulse/Break.expected.c
@@ -7,21 +7,8 @@ void Break_simple_break(void)
 {
   bool k = true;
   bool _break = false;
-  bool cond;
-  if (_break)
-    cond = false;
-  else
-    cond = k;
-  while (cond)
-  {
+  while (!_break && k)
     _break = true;
-    bool ite;
-    if (_break)
-      ite = false;
-    else
-      ite = k;
-    cond = ite;
-  }
 }
 
 void Break_break_continue_and_return(uint8_t which)

--- a/test/pulse/Example_Hashtable.expected.c
+++ b/test/pulse/Example_Hashtable.expected.c
@@ -248,12 +248,7 @@ insert__size_t_Example_Hashtable_data(
   size_t off = (size_t)0U;
   size_t idx = (size_t)0U;
   bool _break = false;
-  bool cond;
-  if (_break)
-    cond = false;
-  else
-    cond = true;
-  while (cond)
+  while (!_break)
   {
     size_t voff = off;
     size_t sum = cidx + voff;
@@ -334,12 +329,6 @@ insert__size_t_Example_Hashtable_data(
         "unreachable (pattern matches are exhaustive in F*)");
       KRML_HOST_EXIT(255U);
     }
-    bool ite;
-    if (_break)
-      ite = false;
-    else
-      ite = true;
-    cond = ite;
   }
   size_t __anf0 = idx;
   write_ref__Pulse_Lib_HashTable_Spec_cell_size_t_Example_Hashtable_data(&contents,

--- a/test/pulse/Null.expected.c
+++ b/test/pulse/Null.expected.c
@@ -17,9 +17,6 @@ krml_checked_int_t *Null_foo(void)
 
 krml_checked_int_t Null_test(krml_checked_int_t *x1)
 {
-  if (x1 == NULL)
-    return (krml_checked_int_t)0;
-  else
-    return *x1;
+  return x1 == NULL ? (krml_checked_int_t)0 : *x1;
 }
 

--- a/test/pulse/Ternary.expected.c
+++ b/test/pulse/Ternary.expected.c
@@ -1,0 +1,52 @@
+/* krml header omitted for test repeatability */
+
+
+#include "Ternary.h"
+
+uint32_t Ternary_u32min(uint32_t x, uint32_t y)
+{
+  return x < y ? x : y;
+}
+
+uint32_t Ternary_test2(uint32_t x, uint32_t y, uint32_t w, uint32_t z)
+{
+  return (x < y ? x : y) + (w < z ? w : z);
+}
+
+uint32_t Ternary_u32min__(uint32_t x, uint32_t y)
+{
+  uint32_t res = x < y ? x : y;
+  return res + 1U;
+}
+
+uint32_t Ternary_u32min___(uint32_t x, uint32_t y)
+{
+  return (x < y ? x : y) + 1U;
+}
+
+uint32_t Ternary_call(bool b, uint32_t (*f)(void), uint32_t (*g)(void))
+{
+  if (b)
+    return f();
+  else
+    return g();
+}
+
+uint32_t Ternary_u32clamp(uint32_t x, uint32_t lo, uint32_t hi)
+{
+  return x < lo ? lo : x > hi ? hi : x;
+}
+
+bool Ternary_is_in_range(uint32_t x, uint32_t lo, uint32_t hi)
+{
+  return !(x < lo) && !(x > hi);
+}
+
+void Ternary_actual_if(bool b, void (*f)(void), void (*g)(void))
+{
+  if (b)
+    f();
+  else
+    g();
+}
+

--- a/test/pulse/Ternary.fst
+++ b/test/pulse/Ternary.fst
@@ -1,0 +1,56 @@
+module Ternary
+
+#lang-pulse
+open Pulse
+module U32 = FStar.UInt32
+
+let u32min (x y : U32.t) =
+  let open U32 in
+  if x <^ y then x else y
+
+inline_for_extraction noextract
+let u32min' (x y : U32.t) =
+  let open U32 in
+  if x <^ y then x else y
+
+let test2 (x y w z : U32.t) =
+  let open U32 in
+  u32min' x y +%^ u32min' w z
+
+let u32min'' (x y : U32.t) =
+  let open U32 in
+  let res = if x <^ y then x else y in
+  res +%^ 1ul
+
+let u32min''' (x y : U32.t) =
+  let open U32 in
+  [@@CInline] let res = if x <^ y then x else y in
+  res +%^ 1ul
+
+(* This should generate an actual if statement. *)
+let call (b : bool) (f g : unit -> U32.t) =
+  if b then f () else g ()
+
+(* Nested ternary *)
+let u32clamp (x lo hi : U32.t) =
+  let open U32 in
+  if x <^ lo then lo
+  else if x >^ hi then hi
+  else x
+
+(* Boolean ternary *)
+let is_in_range (x lo hi : U32.t) : bool =
+  let open U32 in
+  if x <^ lo then false
+  else if x >^ hi then false
+  else true
+
+(* This should generate an actual if statement. *)
+fn actual_if (b : bool) (f g : unit -> stt unit emp (fun _ -> emp))
+  {
+    if b {
+      f ();
+    } else {
+      g ();
+    }
+  }


### PR DESCRIPTION

This automatically translates if-then-else to the ternary operator when
the arguments are pure expressions. `ETernary` is added as an AST node,
and a pass over the AST tries to turn some `EIfThenElse` (as long as the
arguments are pure and without intermediate statements) into `ETernary`,
which get printed as C's `?:`. This is implemented here and not in, say,
AstToCStar, since by that point the `EIfThenElse` nodes have been
flattened into blocks and assignments to intermediate variables, so the
structure is lost.

Requiring the arguments to be pure is just a heuristic and not need. The
requirement for no intermediate definitions is meant to prevent trying
to use a ternary op for something like `f () && (let x = g() in h x)`,
since the RHS must be a block.

When generating Rust or CFlat, `ETernary` nodes are turned back into
`EIfThenElse`, reversing the heuristic detection.

The flag defaults to false, but making it default to true would pass the
test suite (modulo some output changing). Below is an excerpt of the
diff that we would generate if this flag became the default. Some of it
is quite desirable, particularly as the ternary ops fully disappear and
we just end up simplifying blocks away!

AI disclaimer: This was mostly hand written, just with some help from
Claude to figure out what to do about #ifdef detection and having it add
a few tests.

This is based on the constant folding of bools since that becomes more
important after this patch. (Though not strictly necessary.)

```diff
diff --git a/krmllib/dist/generic/FStar_Attributes.c b/krmllib/dist/generic/FStar_Attributes.c
index https://github.com/FStarLang/karamel/commit/2a2d2603a0193b9bfee920d4c2024111b5664566..678323ce 100644
--- a/krmllib/dist/generic/FStar_Attributes.c
+++ b/krmllib/dist/generic/FStar_Attributes.c
@@ -11,14 +11,7 @@ FStar_Attributes_uu___is_PpxDerivingShow(
   FStar_Attributes___internal_ocaml_attributes projectee
 )
 {
-  if (projectee.tag == FStar_Attributes_PpxDerivingShow)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return projectee.tag == FStar_Attributes_PpxDerivingShow;
 }

 bool
diff --git a/krmllib/dist/generic/FStar_Order.c b/krmllib/dist/generic/FStar_Order.c
index https://github.com/FStarLang/karamel/commit/04862dffce69ab63914f19a194489a7e4fbb4751..2eeab533 100644
--- a/krmllib/dist/generic/FStar_Order.c
+++ b/krmllib/dist/generic/FStar_Order.c
@@ -113,13 +113,9 @@ FStar_Order_order FStar_Order_order_from_int(krml_checked_int_t i)
   {
     return FStar_Order_Lt;
   }
-  else if (i == (krml_checked_int_t)0)
-  {
-    return FStar_Order_Eq;
-  }
   else
   {
-    return FStar_Order_Gt;
+    return i == (krml_checked_int_t)0 ? FStar_Order_Eq : FStar_Order_Gt;
   }
 }

diff --git a/krmllib/dist/generic/FStar_UInt128_Verified.h b/krmllib/dist/generic/FStar_UInt128_Verified.h
index https://github.com/FStarLang/karamel/commit/7aa2a6d83f9c4b922f65a310c59c60d8147644f7..1f3e2694 100644
--- a/krmllib/dist/generic/FStar_UInt128_Verified.h
+++ b/krmllib/dist/generic/FStar_UInt128_Verified.h
@@ -159,14 +159,9 @@ FStar_UInt128_shift_left_large(FStar_UInt128_uint128 a, uint32_t s)
 static inline FStar_UInt128_uint128
 FStar_UInt128_shift_left(FStar_UInt128_uint128 a, uint32_t s)
 {
-  if (s < FStar_UInt128_u32_64)
-  {
-    return FStar_UInt128_shift_left_small(a, s);
-  }
-  else
-  {
-    return FStar_UInt128_shift_left_large(a, s);
-  }
+  return
+    s < FStar_UInt128_u32_64 ? FStar_UInt128_shift_left_small(a, s) : FStar_UInt128_shift_left_large(a,
+      s);
 }

 static inline uint64_t FStar_UInt128_add_u64_shift_right(uint64_t hi, uint64_t lo, uint32_t s)
diff --git a/krmllib/dist/generic/WasmSupport.c b/krmllib/dist/generic/WasmSupport.c
index https://github.com/FStarLang/karamel/commit/989ee03c84013c7d7536f34db84402e88a3ee783..e8a37158 100644
--- a/krmllib/dist/generic/WasmSupport.c
+++ b/krmllib/dist/generic/WasmSupport.c
@@ -8,14 +8,7 @@

 uint32_t WasmSupport_align_64(uint32_t x)
 {
-  if (!((x & 0x07U) == 0U))
-  {
-    return (x & 4294967288U) + 0x08U;
-  }
-  else
-  {
-    return x;
-  }
+  return !((x & 0x07U) == 0U) ? (x & 4294967288U) + 0x08U : x;
 }

 void WasmSupport_check_buffer_size(uint32_t s)
diff --git a/test/pulse/Break.expected.c b/test/pulse/Break.expected.c
index https://github.com/FStarLang/karamel/commit/979c520eb8baca83aadb9cdb1af0c81dc158a7e5..f456a21c 100644
--- a/test/pulse/Break.expected.c
+++ b/test/pulse/Break.expected.c
@@ -7,21 +7,8 @@ void Break_simple_break(void)
 {
   bool k = true;
   bool _break = false;
-  bool cond;
-  if (_break)
-    cond = false;
-  else
-    cond = k;
-  while (cond)
-  {
+  while (!_break && k)
     _break = true;
-    bool ite;
-    if (_break)
-      ite = false;
-    else
-      ite = k;
-    cond = ite;
-  }
 }

 void Break_break_continue_and_return(uint8_t which)
diff --git a/test/pulse/Example_Hashtable.expected.c b/test/pulse/Example_Hashtable.expected.c
index https://github.com/FStarLang/karamel/commit/353fbbf99e157f3c5dcdaac3861f713e975335df..8b2f92d4 100644
--- a/test/pulse/Example_Hashtable.expected.c
+++ b/test/pulse/Example_Hashtable.expected.c
@@ -248,12 +248,7 @@ insert__size_t_Example_Hashtable_data(
   size_t off = (size_t)0U;
   size_t idx = (size_t)0U;
   bool _break = false;
-  bool cond;
-  if (_break)
-    cond = false;
-  else
-    cond = true;
-  while (cond)
+  while (!_break)
   {
     size_t voff = off;
     size_t sum = cidx + voff;
@@ -334,12 +329,6 @@ insert__size_t_Example_Hashtable_data(
         "unreachable (pattern matches are exhaustive in F*)");
       KRML_HOST_EXIT(255U);
     }
-    bool ite;
-    if (_break)
-      ite = false;
-    else
-      ite = true;
-    cond = ite;
   }
   size_t __anf0 = idx;
   write_ref__Pulse_Lib_HashTable_Spec_cell_size_t_Example_Hashtable_data(&contents,
diff --git a/test/pulse/Null.expected.c b/test/pulse/Null.expected.c
index https://github.com/FStarLang/karamel/commit/3244f62de58ac482496a8be3b15ce6f0fc94aa1a..d3711b80 100644
--- a/test/pulse/Null.expected.c
+++ b/test/pulse/Null.expected.c
@@ -17,9 +17,6 @@ krml_checked_int_t *Null_foo(void)

 krml_checked_int_t Null_test(krml_checked_int_t *x1)
 {
-  if (x1 == NULL)
-    return (krml_checked_int_t)0;
-  else
-    return *x1;
+  return x1 == NULL ? (krml_checked_int_t)0 : *x1;
 }
```