### PR TITLE
Remove Bool width

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -21,7 +21,7 @@ $ cd eurydice
 $ (cd karamel && git fetch && git checkout my-pr-branch && git merge)
 $ (cd out/ && git clean -fdx)
 $ make test -j
-$ nix flake update karamel --override-input karamel "github:fstarlang/karamel/$(cd karamel && git rev-parse head)"
+$ nix flake update karamel --override-input karamel "github:fstarlang/karamel/$(cd karamel && git rev-parse HEAD)"
 $ git commit -am "Update krml to latest revision on branch my-pr-branch"
 ```
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -214,7 +214,7 @@ type expr' =
   | EOpen of ident * atom_t
     (** [ident] for debugging purposes only *)
 
-  | EOp of op * width
+  | EOp of op * typ_wo
   | EQualified of lident
   | EConstant of constant
   | EUnit

--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -840,7 +840,7 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
       failwith "TODO: implement manual memory management"
 
   | EBool b ->
-      locals, EBool b
+      locals, Bool b
 
   | ECast (e, TInt wt) ->
       let wf = match e.typ with TInt wf -> wf | _ -> failwith "non-int cast" in

--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -751,7 +751,13 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
       let o = K.op_of_poly_comp c in
       locals, CF.CallOp ((w, o), es)
 
-  | EApp ({ node = EOp (o, w); _ }, es) ->
+  | EApp ({ node = EOp (o, TBool); _ }, es) ->
+      let locals, es = fold (mk_expr env) locals es in
+      (* Bools are Int32 *)
+      let w = K.Int32 in
+      locals, CF.CallOp ((w, o), es)
+
+  | EApp ({ node = EOp (o, TInt w); _ }, es) ->
       let locals, es = fold (mk_expr env) locals es in
       locals, CF.CallOp ((w, o), es)
 
@@ -834,7 +840,7 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
       failwith "TODO: implement manual memory management"
 
   | EBool b ->
-      locals, CF.Constant (K.Bool, if b then "1" else "0")
+      locals, EBool b
 
   | ECast (e, TInt wt) ->
       let wf = match e.typ with TInt wf -> wf | _ -> failwith "non-int cast" in

--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -309,7 +309,7 @@ and mask w e =
   | _ -> e
 
 and is_integer_arith op w =
-  w <> K.Bool && not (Constant.is_float w) && K.is_unsigned w && match op with
+  not (Constant.is_float w) && K.is_unsigned w && match op with
   | K.Add | AddW | Sub | SubW | Div | DivW | Mult | MultW | Mod
   | BOr | BAnd | BXor | BShiftL | BShiftR | BNot
   | Eq | Neq | Lt | Lte | Gt | Gte ->
@@ -333,7 +333,7 @@ and is_integer_arith op w =
 and mk_arith env e =
   let mask_if is_atomic w e = if is_atomic then e else mask w e in
   match e.node with
-  | EApp ({ node = EOp (op, w); _ }, [ e1; e2 ]) when is_integer_arith op w ->
+  | EApp ({ node = EOp (op, TInt w); _ }, [ e1; e2 ]) when is_integer_arith op w ->
       let e1, a1, w1 = mk_arith env e1 in
       let e2, a2, w2 = mk_arith env e2 in
       begin match op with
@@ -353,7 +353,7 @@ and mk_arith env e =
       | _ ->
           assert false
       end, false, w1 || w2
-  | EApp ({ node = EOp (BNot, w); _ }, [ e1 ]) when is_integer_arith BNot w ->
+  | EApp ({ node = EOp (BNot, TInt w); _ }, [ e1 ]) when is_integer_arith BNot w ->
       (* BNot is unary. Complement always corrupts upper bits for UInt8/UInt16
          (~(uint8_t)0x0F promotes to int 0xFFFFFFF0), so we must mask. *)
       let e1, _, w1 = mk_arith env e1 in
@@ -415,7 +415,7 @@ and mk_expr env in_stmt under_initializer_list e =
       let ret_t = CStar.Type (mk_type env (MonomorphizationState.normalize e.typ)) in
       unit_to_void env e0 (cgs @ cgs') (List.map (fun t -> CStar.Type (mk_type env t)) ts @ [ ret_t ])
 
-  | EApp ({ node = EOp (op, w); _ }, [ _; _ ]) when is_integer_arith op w ->
+  | EApp ({ node = EOp (op, TInt w); _ }, [ _; _ ]) when is_integer_arith op w ->
       let e', _, widened = mk_arith env e in
       if !Options.cxx_compat && under_initializer_list && widened then
         Cast (e', mk_type env e.typ)
@@ -533,13 +533,13 @@ and mk_stmts env e ret_type =
     | EFor (binder,
       ({ node = EConstant ((K.UInt32 | K.SizeT), init as k_init); _ } as e_init),
       { node = EApp (
-        { node = EOp (K.Lt, (K.UInt32 | K.SizeT)); _ },
+        { node = EOp (K.Lt, TInt (K.UInt32 | K.SizeT)); _ },
         [{ node = EBound 0; _ };
         ({ node = EConstant ((K.UInt32 | K.SizeT), max as k_max); _ } as e_max)]); _},
       { node = EAssign (
         { node = EBound 0; _ },
         { node = EApp (
-          { node = EOp (K.Add, (K.UInt32 | K.SizeT)); _ },
+          { node = EOp (K.Add, TInt (K.UInt32 | K.SizeT)); _ },
           [{ node = EBound 0; _ };
           ({ node = EConstant ((K.UInt32 | K.SizeT), incr as k_incr); _ } as e_incr)]); _}); _},
       body)
@@ -787,7 +787,7 @@ and mk_stmts env e ret_type =
        * ill-parenthesized, or if there's B1 && B'1
        *)
       match e1.node with
-      | EApp ({ node = EOp (K.And, K.Bool); _ }, [ e1; e1' ]) when return_pos <> Not ->
+      | EApp ({ node = EOp (K.And, TBool); _ }, [ e1; e1' ]) when return_pos <> Not ->
           let cond = mk_ifcond env e1 in
           (* Can't recursively call mk_block with Must because it'll insert a
            * return in the else-branch. *)
@@ -815,9 +815,9 @@ and mk_stmts env e ret_type =
     match e.node with
     | EQualified name when LidSet.mem name env.ifdefs ->
         CStar.Macro name
-    | EApp ({ node = EOp ((K.And | K.Or) as o, K.Bool); _ }, [ e1; e2 ]) ->
+    | EApp ({ node = EOp ((K.And | K.Or) as o, TBool); _ }, [ e1; e2 ]) ->
         CStar.Call (CStar.Op o, [ mk_ifcond env e1; mk_ifcond env e2 ])
-    | EApp ({ node = EOp (K.Not as o, K.Bool); _ }, [ e1 ]) ->
+    | EApp ({ node = EOp (K.Not as o, TBool); _ }, [ e1 ]) ->
         CStar.Call (CStar.Op o, [ mk_ifcond env e1 ])
     | _ ->
         raise NotIfDef

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -873,7 +873,7 @@ and translate_expr_with_type (env: env) ?(context=`Other) (fn_t_ret: MiniRust.ty
   | EUnit ->
       env, Unit
   | EBool b ->
-      env, EBool b
+      env, Bool b
   | EString s ->
       env, ConstantString s
   | EAny -> failwith "Unexpected EAny"
@@ -955,8 +955,8 @@ and translate_expr_with_type (env: env) ?(context=`Other) (fn_t_ret: MiniRust.ty
   | EApp ({ node = EPolyComp (op, TBuf _); _ }, ([ { node = EBufNull; _ }; _ ] | [ _; { node = EBufNull; _ }])) ->
       (* No null-checks in Rust -- function will panic. *)
       begin match op with
-      | PEq -> env, EBool false (* nothing is ever null *)
-      | PNeq -> env, EBool true (* everything is always non-null *)
+      | PEq -> env, Bool false (* nothing is ever null *)
+      | PNeq -> env, Bool true (* everything is always non-null *)
       end
 
   | EApp (e0, es) ->

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -536,7 +536,7 @@ let has_pointer env =
 let rec translate_type_with_config (env: env) (config: config) (t: Ast.typ): MiniRust.typ =
   match t with
   | TInt w -> Constant w
-  | TBool -> Constant Bool
+  | TBool -> Bool
   | TUnit -> Unit
   | TAny -> failwith "unexpected: [type] no casts in Low* -> Rust"
   | TBuf (t, b) ->
@@ -873,7 +873,7 @@ and translate_expr_with_type (env: env) ?(context=`Other) (fn_t_ret: MiniRust.ty
   | EUnit ->
       env, Unit
   | EBool b ->
-      env, Constant (Bool, string_of_bool b)
+      env, EBool b
   | EString s ->
       env, ConstantString s
   | EAny -> failwith "Unexpected EAny"
@@ -884,7 +884,7 @@ and translate_expr_with_type (env: env) ?(context=`Other) (fn_t_ret: MiniRust.ty
       let env, e = translate_expr env fn_t_ret e in
       let binding: MiniRust.binding = { name = "_"; typ = t; mut = false; ref = false } in
       env, Let (binding, Some e, Unit)
-  | EApp ({ node = EOp (o, w); _ }, es) when H.is_wrapping_operator o && not (Constant.is_float w) ->
+  | EApp ({ node = EOp (o, TInt w); _ }, es) when H.is_wrapping_operator o && not (Constant.is_float w) ->
       let w = Helpers.assert_tint (List.hd es).typ in
       let env, es = translate_expr_list env fn_t_ret es in
       env, possibly_convert (MethodCall (List.hd es, [ H.wrapping_operator o ], List.tl es)) (Constant w)
@@ -955,8 +955,8 @@ and translate_expr_with_type (env: env) ?(context=`Other) (fn_t_ret: MiniRust.ty
   | EApp ({ node = EPolyComp (op, TBuf _); _ }, ([ { node = EBufNull; _ }; _ ] | [ _; { node = EBufNull; _ }])) ->
       (* No null-checks in Rust -- function will panic. *)
       begin match op with
-      | PEq -> env, Constant (Bool, "false") (* nothing is ever null *)
-      | PNeq ->  env, Constant (Bool, "true") (* everything is always non-null *)
+      | PEq -> env, EBool false (* nothing is ever null *)
+      | PNeq -> env, EBool true (* everything is always non-null *)
       end
 
   | EApp (e0, es) ->

--- a/lib/CFlat.ml
+++ b/lib/CFlat.ml
@@ -115,7 +115,7 @@ and expr =
   | Var of var
   | GetGlobal of ident
   | Constant of constant
-  | EBool of bool
+  | Bool of bool
   | Assign of var * expr
   | StringLiteral of string
   | Abort of expr

--- a/lib/CFlat.ml
+++ b/lib/CFlat.ml
@@ -68,7 +68,7 @@ module Sizes = struct
         A16
     | UInt8 | Int8 ->
         A8
-    | Bool | SizeT | PtrdiffT ->
+    | SizeT | PtrdiffT ->
         invalid_arg "array_size_of_width"
 
   let bytes_in = function
@@ -115,6 +115,7 @@ and expr =
   | Var of var
   | GetGlobal of ident
   | Constant of constant
+  | EBool of bool
   | Assign of var * expr
   | StringLiteral of string
   | Abort of expr

--- a/lib/CFlatToWasm.ml
+++ b/lib/CFlatToWasm.ml
@@ -663,8 +663,8 @@ and mk_expr env (e: expr): W.Ast.instr list =
   | Constant (w, lit) ->
       mk_const (mk_lit w lit)
 
-  | EBool true  -> mk_const (mk_int32 Int32.one)
-  | EBool false -> mk_const (mk_int32 Int32.zero)
+  | Bool true  -> mk_const (mk_int32 Int32.one)
+  | Bool false -> mk_const (mk_int32 Int32.zero)
 
   | CallOp (o, [ e1 ]) ->
       mk_callop env o e1

--- a/lib/CFlatToWasm.ml
+++ b/lib/CFlatToWasm.ml
@@ -211,7 +211,7 @@ let mk_lit w lit =
       let n = Z.of_string lit in
       let n = if Z.( n >= ~$2 ** 63 ) then Z.( n - ~$2 ** 64 ) else n in
       mk_int64 (Z.to_int64 n)
-  | K.Int32 | K.UInt8 | K.UInt16 | K.UInt32 | K.SizeT | K.PtrdiffT | K.Bool | K.CInt ->
+  | K.Int32 | K.UInt8 | K.UInt16 | K.UInt32 | K.SizeT | K.PtrdiffT | K.CInt ->
       let n = Z.of_string lit in
       let n = if Z.( n >= ~$2 ** 31 ) then Z.( n - ~$2 ** 32 ) else n in
       mk_int32 (Z.to_int32 n)
@@ -521,8 +521,6 @@ let mk_cast w_from w_to =
   | UInt16, UInt8
   | UInt32, (UInt16 | UInt8) ->
       mk_mask w_to
-  | Bool, _ | _, Bool ->
-      invalid_arg "mk_cast"
   | _ ->
       Warn.fatal_error "todo: conversion from %s to %s"
         (show_width w_from) (show_width w_to)
@@ -664,6 +662,9 @@ and mk_expr env (e: expr): W.Ast.instr list =
 
   | Constant (w, lit) ->
       mk_const (mk_lit w lit)
+
+  | EBool true  -> mk_const (mk_int32 Int32.one)
+  | EBool false -> mk_const (mk_int32 Int32.zero)
 
   | CallOp (o, [ e1 ]) ->
       mk_callop env o e1

--- a/lib/Constant.ml
+++ b/lib/Constant.ml
@@ -8,7 +8,6 @@ type t = width * string
 
 and width =
   | UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64
-  | Bool
   | CInt (** Checked signed integers. *)
   | SizeT | PtrdiffT
   | Float32 | Float64 (** Floating point numbers. *)
@@ -67,13 +66,12 @@ let unsigned_of_signed = function
   | Int32 -> UInt32
   | Int64 -> UInt64
   | PtrdiffT -> SizeT
-  | CInt | UInt8 | UInt16 | UInt32 | UInt64 | SizeT | Bool
+  | CInt | UInt8 | UInt16 | UInt32 | UInt64 | SizeT
   | Float32 | Float64 -> raise (Invalid_argument "unsigned_of_signed")
 
 let is_signed = function
   | Int8 | Int16 | Int32 | Int64 | CInt | PtrdiffT -> true
   | UInt8 | UInt16 | UInt32 | UInt64 | SizeT -> false
-  | Bool -> raise (Invalid_argument "is_signed: bool")
   | Float32 | Float64 -> raise (Invalid_argument "is_signed: float")
 
 let is_unsigned w = not (is_signed w)

--- a/lib/DataTypes.ml
+++ b/lib/DataTypes.ml
@@ -845,25 +845,23 @@ let is_special name =
   Helpers.is_uu name
 
 let rec is_trivially_true e =
-  let open Constant in
   match e.node with
   | EBool b ->
       b = true
-  | EApp ({ node = EOp (K.And, Bool); _ }, [ e1; e2 ]) ->
+  | EApp ({ node = EOp (K.And, TBool); _ }, [ e1; e2 ]) ->
       is_trivially_true e1 && is_trivially_true e2
-  | EApp ({ node = EOp (K.Or, Bool); _ }, [ e1; e2 ]) ->
+  | EApp ({ node = EOp (K.Or, TBool); _ }, [ e1; e2 ]) ->
       is_trivially_true e1 || is_trivially_true e2
   | _ ->
       false
 
 and is_trivially_false e =
-  let open Constant in
   match e.node with
   | EBool b ->
       b = false
-  | EApp ({ node = EOp (K.And, Bool); _ }, [ e1; e2 ]) ->
+  | EApp ({ node = EOp (K.And, TBool); _ }, [ e1; e2 ]) ->
       is_trivially_false e1 || is_trivially_false e2
-  | EApp ({ node = EOp (K.Or, Bool); _ }, [ e1; e2 ]) ->
+  | EApp ({ node = EOp (K.Or, TBool); _ }, [ e1; e2 ]) ->
       is_trivially_false e1 && is_trivially_false e2
   | _ ->
       false
@@ -920,9 +918,8 @@ end
 
 let union_field_of_cons = (^) "case_"
 
-let mk_eq w e1 e2 =
-  let t = if w = K.Bool then TBool else TInt w in
-  let eq = with_type (TArrow (t, TArrow (t, TBool))) (EOp (K.Eq, w)) in
+let mk_eq t e1 e2 =
+  let eq = with_type (TArrow (t, TArrow (t, TBool))) (EOp (K.Eq, t)) in
   with_type TBool (EApp (eq, [ e1; e2 ]))
 
 let mk_poly_eq t e1 e2 =
@@ -937,7 +934,7 @@ let rec compile_pattern env scrut pat expr =
       (* why generate a conditional here?? *)
       [ mk_poly_eq TUnit scrut Helpers.eunit ], expr
   | PBool b ->
-      [ mk_eq K.Bool scrut (with_type TBool (EBool b)) ], expr
+      [ mk_eq TBool scrut (with_type TBool (EBool b)) ], expr
   | PEnum lid ->
       [ mk_poly_eq pat.typ scrut (with_type pat.typ (EEnum lid)) ], expr
   | PRecord fields ->
@@ -968,7 +965,7 @@ let rec compile_pattern env scrut pat expr =
       let scrut = with_type (Helpers.assert_tbuf_or_tarray scrut.typ) (EBufRead (scrut, zerou32)) in
       compile_pattern env scrut pat expr
   | PConstant k ->
-      [ mk_eq (fst k) scrut (with_type (TInt (fst k)) (EConstant k)) ], expr
+      [ mk_eq (TInt (fst k)) scrut (with_type (TInt (fst k)) (EConstant k)) ], expr
 
 
 let rec mk_conjunction = function
@@ -977,7 +974,7 @@ let rec mk_conjunction = function
   | [ e1 ] ->
       e1
   | e1 :: es ->
-      with_type TBool (EApp (with_type (TArrow (TBool, TArrow (TBool, TBool))) (EOp (K.And, K.Bool)), [ e1; mk_conjunction es ]))
+      with_type TBool (EApp (with_type (TArrow (TBool, TArrow (TBool, TBool))) (EOp (K.And, TBool)), [ e1; mk_conjunction es ]))
 
 let compile_branch env scrut (binders, pat, expr): expr * expr =
   let _binders, pat, expr = open_branch binders pat expr in

--- a/lib/Helpers.ml
+++ b/lib/Helpers.ml
@@ -33,25 +33,33 @@ let uint32 = TInt K.UInt32
 let uint64 = TInt K.UInt64
 let usize = TInt K.SizeT
 
-let type_of_op op w =
+let is_TInt = function TInt _ -> true | _ -> false
+let type_of_op op (t : typ) : typ =
   let open Constant in
+  (* Very defensive asserts here. *)
   match op with
   | Add | AddW | Sub | SubW | Div | DivW | Mult | MultW | Mod
   | BOr | BAnd | BXor ->
-      TArrow (TInt w, TArrow (TInt w, TInt w))
+      assert (is_TInt t);
+      TArrow (t, TArrow (t, t))
   | BShiftL | BShiftR ->
-      TArrow (TInt w, TArrow (uint32, TInt w))
+      assert (is_TInt t);
+      TArrow (t, TArrow (uint32, t))
   | Eq | Neq ->
-      let t = if w = Bool then TBool else TInt w in
+      assert (is_TInt t || t = TBool);
       TArrow (t, TArrow (t, TBool))
   | Lt | Lte | Gt | Gte ->
-      TArrow (TInt w, TArrow (TInt w, TBool))
+      assert (is_TInt t);
+      TArrow (t, TArrow (t, TBool))
   | And | Or | Xor ->
+      assert (t = TBool);
       TArrow (TBool, TArrow (TBool, TBool))
   | Not ->
+      assert (t = TBool);
       TArrow (TBool, TBool)
   | BNot | Neg ->
-      TArrow (TInt w, TInt w)
+      assert (is_TInt t);
+      TArrow (t, t)
   | Assign | PreIncr | PreDecr | PostIncr | PostDecr | Comma ->
       invalid_arg "type_of_op"
 
@@ -78,9 +86,10 @@ let mk_op op w =
 
 (* @0 < <finish> *)
 let mk_lt w finish =
+  let t = TInt w in
   with_type TBool (
-    EApp (mk_op K.Lt w, [
-      with_type (TInt w) (EBound 0);
+    EApp (mk_op K.Lt t, [
+      with_type t (EBound 0);
       finish ]))
 
 let mk_lt32 =
@@ -95,7 +104,7 @@ let mk_incr_e w e =
   with_type TUnit (
     EAssign (with_type t (
       EBound 0), with_type t (
-      EApp (mk_op K.Add w, [
+      EApp (mk_op K.Add t, [
         with_type t (EBound 0);
         e ]))))
 
@@ -106,19 +115,19 @@ let mk_incr32 = mk_incr K.UInt32
 let mk_incr_usize = mk_incr K.SizeT
 
 let assert_tint_or_tbool t =
-  match t with TInt w -> w | TBool -> Bool | t -> Warn.fatal_error "Not an int/bool: %a" ptyp t
+  match t with TInt w -> TInt w | TBool -> TBool | t -> Warn.fatal_error "Not an int/bool: %a" ptyp t
 
 let mk_neq e1 e2 =
   with_type TBool (EApp (mk_op K.Neq (assert_tint_or_tbool e1.typ), [ e1; e2 ]))
 
 let mk_not e1 =
-  with_type TBool (EApp (mk_op K.Not K.Bool, [ e1 ]))
+  with_type TBool (EApp (mk_op K.Not TBool, [ e1 ]))
 
 let mk_and e1 e2 =
-  with_type TBool (EApp (mk_op K.And K.Bool, [ e1; e2 ]))
+  with_type TBool (EApp (mk_op K.And TBool, [ e1; e2 ]))
 
 let mk_or e1 e2 =
-  with_type TBool (EApp (mk_op K.Or K.Bool, [ e1; e2 ]))
+  with_type TBool (EApp (mk_op K.Or TBool, [ e1; e2 ]))
 
 let mk_uint32 i =
   with_type (TInt K.UInt32) (EConstant (K.UInt32, string_of_int i))
@@ -130,7 +139,7 @@ let mk_sizet i =
 let mk_minus_one e =
   with_type uint32 (
     EApp (
-      mk_op K.Sub K.UInt32, [
+      mk_op K.Sub (TInt K.UInt32), [
       e;
       oneu32
     ]))
@@ -138,7 +147,7 @@ let mk_minus_one e =
 (* e > 0 *)
 let mk_gt_zero e =
   with_type TBool (
-    EApp (mk_op K.Gt K.UInt32, [
+    EApp (mk_op K.Gt (TInt K.UInt32), [
       e;
       zerou32]))
 
@@ -224,14 +233,14 @@ let is_ifdef ifdefs e1 =
     match e.node with
     | EQualified lid when Idents.LidSet.mem lid ifdefs ->
         true
-    | EApp ({ node = EOp ((K.And | K.Or), K.Bool); _ }, [ e1; e2 ]) ->
+    | EApp ({ node = EOp ((K.And | K.Or), TBool); _ }, [ e1; e2 ]) ->
         is_ifdef e1 && is_ifdef e2
-    | EApp ({ node = EOp (K.Not, K.Bool); _ }, [ e1 ]) ->
+    | EApp ({ node = EOp (K.Not, TBool); _ }, [ e1 ]) ->
         is_ifdef e1
     | _ -> false
   in
   match e1.node with
-  | EApp ({ node = EOp (K.And, K.Bool); _ }, [ e1; e2 ]) ->
+  | EApp ({ node = EOp (K.And, TBool); _ }, [ e1; e2 ]) ->
       (* e2 will appear underneath the #if and thus deserves special
          treatment. *)
       if is_ifdef e1 then
@@ -399,7 +408,7 @@ let rec is_int_constant e =
       | BOr | BAnd | BXor | BShiftL | BShiftR | BNot
       | Eq | Neq | Lt | Lte | Gt | Gte
       | And | Or | Xor | Not), w); _ },
-    es) when w <> CInt ->
+    es) when w <> TInt CInt ->
       List.for_all is_int_constant es
   | _ ->
       false

--- a/lib/InputAst.ml
+++ b/lib/InputAst.ml
@@ -6,7 +6,7 @@
 open Utils
 open Common
 
-module K = Constant
+module K = InputConstant
 
 (** The input AST. Note: F* doesn't have flat data constructors, so we need to introduce
  * (inefficient) boxing for the sake of interop. Other note: this is using the

--- a/lib/InputAstToAst.ml
+++ b/lib/InputAstToAst.ml
@@ -7,6 +7,7 @@ open Ast
 open Common
 
 module I = InputAst
+module IK = InputConstant
 
 let mk (type a) (node: a): a with_type =
   { node; typ = TAny; meta = [] }
@@ -25,6 +26,58 @@ let rec binders_of_pat p =
   | PUnit
   | PBool _ ->
       []
+
+let tr_width (w : IK.width) : K.width =
+  match w with
+  | IK.UInt8 -> K.UInt8
+  | IK.UInt16 -> K.UInt16
+  | IK.UInt32 -> K.UInt32
+  | IK.UInt64 -> K.UInt64
+  | IK.Int8 -> K.Int8
+  | IK.Int16 -> K.Int16
+  | IK.Int32 -> K.Int32
+  | IK.Int64 -> K.Int64
+  | IK.Bool -> K.Bool
+  | IK.CInt -> K.CInt
+  | IK.SizeT -> K.SizeT
+  | IK.PtrdiffT -> K.PtrdiffT
+  | IK.Float32 -> K.Float32
+  | IK.Float64 -> K.Float64
+
+let tr_op (op: IK.op) : K.op =
+  match op with
+  | IK.Add -> K.Add
+  | IK.AddW -> K.AddW
+  | IK.Sub -> K.Sub
+  | IK.SubW -> K.SubW
+  | IK.Div -> K.Div
+  | IK.DivW -> K.DivW
+  | IK.Mult -> K.Mult
+  | IK.MultW -> K.MultW
+  | IK.Mod -> K.Mod
+  | IK.BOr -> K.BOr
+  | IK.BAnd -> K.BAnd
+  | IK.BXor -> K.BXor
+  | IK.BShiftL -> K.BShiftL
+  | IK.BShiftR -> K.BShiftR
+  | IK.BNot -> K.BNot
+  | IK.Eq -> K.Eq
+  | IK.Neq -> K.Neq
+  | IK.Lt -> K.Lt
+  | IK.Lte -> K.Lte
+  | IK.Gt -> K.Gt
+  | IK.Gte -> K.Gte
+  | IK.And -> K.And
+  | IK.Or -> K.Or
+  | IK.Xor -> K.Xor
+  | IK.Not -> K.Not
+  | IK.Assign -> K.Assign
+  | IK.PreIncr -> K.PreIncr
+  | IK.PreDecr -> K.PreDecr
+  | IK.PostIncr -> K.PostIncr
+  | IK.PostDecr -> K.PostDecr
+  | IK.Comma -> K.Comma
+  | IK.Neg -> K.Neg
 
 let width_of_equality = function
   | TInt w -> Some w
@@ -77,6 +130,7 @@ and mk_fields fields =
 
 and mk_constant (w, s) =
   let module T = struct exception Error end in
+  let w = tr_width w in
   let rec skip_zeroes i =
     if i = String.length s then
       i
@@ -105,7 +159,7 @@ and mk_constant (w, s) =
 
 and mk_typ = function
   | I.TInt x ->
-      TInt x
+      TInt (tr_width x)
   | I.TBuf t ->
       TBuf (mk_typ t, false)
   | I.TConstBuf t ->
@@ -160,8 +214,8 @@ and mk_expr = function
 
   | I.EApp (e, es) ->
       mk (EApp (mk_expr e, List.map mk_expr es))
-  | I.ETApp (I.EOp ((K.Eq | K.Neq as op), _), [ t ]) ->
-      let c = match op with K.Eq -> K.PEq | K.Neq -> K.PNeq | _ -> assert false in
+  | I.ETApp (I.EOp ((IK.Eq | IK.Neq as op), _), [ t ]) ->
+      let c = match op with IK.Eq -> K.PEq | IK.Neq -> K.PNeq | _ -> assert false in
       mk (EPolyComp (c, mk_typ t))
   | I.ETApp (e, es) ->
       mk (ETApp (mk_expr e, [], [], List.map mk_typ es))
@@ -198,7 +252,7 @@ and mk_expr = function
   | I.EMatch (e1, bs) ->
       mk (EMatch (Checked, mk_expr e1, mk_branches bs))
   | I.EOp (op, w) ->
-      mk (EOp (op, w))
+      mk (EOp (tr_op op, tr_width w))
   | I.ECast (e1, t) ->
       mk (ECast (mk_expr e1, mk_typ t))
   | I.EPushFrame ->

--- a/lib/InputAstToAst.ml
+++ b/lib/InputAstToAst.ml
@@ -37,12 +37,13 @@ let tr_width (w : IK.width) : K.width =
   | IK.Int16 -> K.Int16
   | IK.Int32 -> K.Int32
   | IK.Int64 -> K.Int64
-  | IK.Bool -> K.Bool
   | IK.CInt -> K.CInt
   | IK.SizeT -> K.SizeT
   | IK.PtrdiffT -> K.PtrdiffT
   | IK.Float32 -> K.Float32
   | IK.Float64 -> K.Float64
+  | IK.Bool ->
+      Warn.fatal_error "Unexpected Bool width in input AST."
 
 let tr_op (op: IK.op) : K.op =
   match op with
@@ -78,12 +79,6 @@ let tr_op (op: IK.op) : K.op =
   | IK.PostDecr -> K.PostDecr
   | IK.Comma -> K.Comma
   | IK.Neg -> K.Neg
-
-let width_of_equality = function
-  | TInt w -> Some w
-  | TBool -> Some K.Bool
-  | TQualified ([ "Prims" ], ("int" | "nat" | "pos")) -> Some K.CInt
-  | _ -> None
 
 let rec mk_decl = function
   | I.DFunction (cc, flags, n, t, name, binders, body) ->
@@ -252,7 +247,16 @@ and mk_expr = function
   | I.EMatch (e1, bs) ->
       mk (EMatch (Checked, mk_expr e1, mk_branches bs))
   | I.EOp (op, w) ->
-      mk (EOp (tr_op op, tr_width w))
+      (* F* generates EOp's with Bool width (remember InputConstant.width
+      includes Bool), but the internal AST doesn't have Bool as a width. We
+      translate these to EOp with TBool type. The remaining widths become TInt
+      w. *)
+      let typ =
+        match w with
+        | IK.Bool -> TBool
+        | _ -> TInt (tr_width w)
+      in
+      mk (EOp (tr_op op, typ))
   | I.ECast (e1, t) ->
       mk (ECast (mk_expr e1, mk_typ t))
   | I.EPushFrame ->

--- a/lib/InputConstant.ml
+++ b/lib/InputConstant.ml
@@ -1,0 +1,35 @@
+(* Copyright (c) INRIA and Microsoft Corporation. All rights reserved. *)
+(* Licensed under the Apache 2.0 and MIT Licenses. *)
+
+(* This file defines the constants used in the input AST.
+   This is separate from Constant.ml to decouple the two. In particular,
+   the InputAst includes a "Bool" width that is not present in
+   the internal Ast. Removing them from the InputAst is an ABI-breaking
+   change that can be done at a later point. *)
+
+type width =
+  | UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64
+  | Bool
+  | CInt (** Checked signed integers. *)
+  | SizeT | PtrdiffT
+  | Float32 | Float64 (** Floating point numbers. *)
+  [@@deriving yojson,show]
+
+type t = width * string
+  [@@deriving yojson,show]
+
+type op =
+  (* Arithmetic operations *)
+  | Add | AddW | Sub | SubW | Div | DivW | Mult | MultW | Mod
+  (* Bitwise operations *)
+  | BOr | BAnd | BXor | BShiftL | BShiftR | BNot
+  (* Arithmetic comparisons / boolean comparisons *)
+  | Eq | Neq | Lt | Lte | Gt | Gte
+  (* Boolean operations *)
+  | And | Or | Xor | Not
+  (* Effectful operations. Only appears in C. *)
+  | Assign | PreIncr | PreDecr | PostIncr | PostDecr
+  (* Misc *)
+  | Comma
+  | Neg
+  [@@deriving yojson,show]

--- a/lib/MiniRust.ml
+++ b/lib/MiniRust.ml
@@ -29,7 +29,7 @@ and db_index = int [@ visitors.opaque ]
 
 type typ =
   | Constant of width (* excludes cint, ptrdifft *) [@name "tconstant"]
-  | Bool
+  | Bool [@name "tbool"]
   | Ref of lifetime option * borrow_kind * typ
   | Vec of typ
   | Array of typ * int [@name "tarray"]
@@ -79,7 +79,7 @@ and expr =
   | Name of name
   | Borrow of borrow_kind * expr
   | Constant of constant
-  | EBool of bool
+  | Bool of bool
   | ConstantString of string
   | Let of binding * expr option * expr
   | Call of expr * typ list * expr list

--- a/lib/MiniRust.ml
+++ b/lib/MiniRust.ml
@@ -29,6 +29,7 @@ and db_index = int [@ visitors.opaque ]
 
 type typ =
   | Constant of width (* excludes cint, ptrdifft *) [@name "tconstant"]
+  | Bool
   | Ref of lifetime option * borrow_kind * typ
   | Vec of typ
   | Array of typ * int [@name "tarray"]
@@ -53,7 +54,6 @@ and lifetime =
 let box t =
   App (Name (["Box"], []), [t])
 
-let bool = Constant Bool
 let u8 = Constant UInt8
 let u16 = Constant UInt16
 let u32 = Constant UInt32
@@ -79,6 +79,7 @@ and expr =
   | Name of name
   | Borrow of borrow_kind * expr
   | Constant of constant
+  | EBool of bool
   | ConstantString of string
   | Let of binding * expr option * expr
   | Call of expr * typ list * expr list

--- a/lib/Monomorphization.ml
+++ b/lib/Monomorphization.ml
@@ -948,16 +948,16 @@ let equalities files =
 
       match t with
       | TQualified ([ "Prims" ], ("int" | "nat" | "pos")) ->
-          EOp (K.op_of_poly_comp op, K.CInt)
+          EOp (K.op_of_poly_comp op, TInt K.CInt)
 
       | TQualified lid when enum_eventually lid ->
           EPolyComp (op, t)
 
       | TInt w ->
-          EOp (K.op_of_poly_comp op, w)
+          EOp (K.op_of_poly_comp op, TInt w)
 
       | TBool ->
-          EOp (K.op_of_poly_comp op, K.Bool)
+          EOp (K.op_of_poly_comp op, TBool)
 
       | TBuf _ ->
           (* 20210205: I don't think this is allowed anymore, at all. Maybe with

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -576,6 +576,7 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
   | VecNew _
   | Name _
   | Constant _
+  | EBool _
   | ConstantString _
   | Unit
   | Panic _
@@ -607,7 +608,7 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
         known, e0
 
   | IfThenElse (e1, e2, e3) ->
-      let known, e1 = infer_expr env valuation return_expected bool known e1 in
+      let known, e1 = infer_expr env valuation return_expected Bool known e1 in
       let known, e2 = infer_expr env valuation return_expected expected known e2 in
       let known, e3 =
         match e3 with
@@ -631,12 +632,12 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
       end
 
   | For (b, e1, e2) ->
-      let known, e1 = infer_expr env valuation return_expected bool known e1 in
+      let known, e1 = infer_expr env valuation return_expected Bool known e1 in
       let known, e2 = infer_expr env valuation return_expected Unit known e2 in
       known, For (b, e1, e2)
 
   | While (e1, e2) ->
-      let known, e1 = infer_expr env valuation return_expected bool known e1 in
+      let known, e1 = infer_expr env valuation return_expected Bool known e1 in
       let known, e2 = infer_expr env valuation return_expected Unit known e2 in
       known, While (e1, e2)
 
@@ -1462,8 +1463,8 @@ let simplify_trivial_branching = object
     let e1 = super#visit_expr () e1 in
     let e2 = Option.map (super#visit_expr ()) e2 in
     match cond with
-    | Constant (Bool, "true") -> e1
-    | Constant (Bool, "false") ->
+    | EBool true -> e1
+    | EBool false ->
         begin match e2 with
         | Some e2 -> e2
         | None -> Unit

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -576,7 +576,7 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
   | VecNew _
   | Name _
   | Constant _
-  | EBool _
+  | Bool _
   | ConstantString _
   | Unit
   | Panic _
@@ -1463,8 +1463,8 @@ let simplify_trivial_branching = object
     let e1 = super#visit_expr () e1 in
     let e2 = Option.map (super#visit_expr ()) e2 in
     match cond with
-    | EBool true -> e1
-    | EBool false ->
+    | Bool true -> e1
+    | Bool false ->
         begin match e2 with
         | Some e2 -> e2
         | None -> Unit

--- a/lib/PrintAst.ml
+++ b/lib/PrintAst.ml
@@ -306,7 +306,7 @@ and print_expr env { node; typ; meta } =
       group (c ^^ string "match" ^/^ print_expr env e ^/^ string "with") ^^
       jump ~indent:0 (print_branches env branches)
   | EOp (o, w) ->
-      string "(" ^^ print_op o ^^ string "," ^^ print_width w ^^ string ")"
+      string "(" ^^ print_op o ^^ string "," ^^ print_typ w ^^ string ")"
   | ECast (e, t) ->
       parens_with_nesting (print_expr env e ^^ langle ^^ colon ^/^ print_typ t)
   | EPopFrame ->

--- a/lib/PrintCommon.ml
+++ b/lib/PrintCommon.ml
@@ -30,7 +30,6 @@ let width_to_string = function
   | Int16 -> if !Options.linux_ints then "s16" else "int16"
   | Int32 -> if !Options.linux_ints then "s32" else "int32"
   | Int64 -> if !Options.linux_ints then "s64" else "int64"
-  | Bool -> "bool"
   | SizeT -> if !Options.linux_ints then "size_t" else "size"
   | PtrdiffT -> if !Options.linux_ints then "ptrdiff_t" else "ptrdiff"
   | Float32 -> "float32"

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -425,7 +425,7 @@ and print_expr env ?(lbrace_conflict=Fine) (context: int) (e: expr): document =
       group (ampersand ^^ print_borrow_kind k ^^ print_expr env mine e)
   | Constant c ->
       print_constant c
-  | EBool b ->
+  | Bool b ->
       string (if b then "true" else "false")
   | Let _ ->
       (* If we reach this point with lbrace_conflict=Danger, then we get bonus

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -167,7 +167,6 @@ let string_of_width (w: Constant.width) =
   | Constant.Int16 -> "i16"
   | Constant.Int32 -> "i32"
   | Constant.Int64 -> "i64"
-  | Constant.Bool -> "bool"
   | Constant.SizeT -> "usize"
   | Constant.CInt -> ""
   | Constant.PtrdiffT -> failwith "unexpected: ptrdifft"
@@ -180,10 +179,7 @@ let print_borrow_kind k =
   | Shared -> empty
 
 let print_constant (w, s) =
-  if w <> Constant.Bool then
-    string s ^^ string (string_of_width w)
-  else
-    string s
+  string s ^^ string (string_of_width w)
 
 let print_lifetime = function
   | Label l ->
@@ -226,6 +222,7 @@ type lbrace_conflict =
 let rec print_typ env (t: typ): document =
   match t with
   | Constant w -> string (string_of_width w)
+  | Bool -> string "bool"
   | Ref (lt, k, t) -> group (ampersand ^^ print_lifetime_option lt ^^ print_borrow_kind k ^^ print_typ env t)
   | Vec t -> group (string "Vec" ^^ angles (print_typ env t))
   | Array (t, n) -> group (brackets (print_typ env t ^^ semi ^/^ int n))
@@ -428,6 +425,8 @@ and print_expr env ?(lbrace_conflict=Fine) (context: int) (e: expr): document =
       group (ampersand ^^ print_borrow_kind k ^^ print_expr env mine e)
   | Constant c ->
       print_constant c
+  | EBool b ->
+      string (if b then "true" else "false")
   | Let _ ->
       (* If we reach this point with lbrace_conflict=Danger, then we get bonus
          parentheses *)

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -393,9 +393,9 @@ let wrapping_arithmetic = object (self)
   (* TODO: this is no longer exposed by F*; check and remove this pass? *)
   method! visit_EApp env e es =
     match e.node, es with
-    | EOp (((K.AddW | K.SubW | K.MultW | K.DivW) as op), w), [ e1; e2 ] when K.is_signed w ->
+    | EOp (((K.AddW | K.SubW | K.MultW | K.DivW) as op), TInt w), [ e1; e2 ] when K.is_signed w ->
         let unsigned_w = K.unsigned_of_signed w in
-        let e = mk_op (K.without_wrap op) unsigned_w in
+        let e = mk_op (K.without_wrap op) (TInt unsigned_w) in
         let e1 = self#visit_expr env e1 in
         let e2 = self#visit_expr env e2 in
         let c e = { node = ECast (e, TInt unsigned_w); typ = TInt unsigned_w; meta = [] } in
@@ -405,8 +405,8 @@ let wrapping_arithmetic = object (self)
         let unsigned_app = { node = EApp (e, [ c e1; c e2 ]); typ = TInt unsigned_w; meta = [] } in
         ECast (unsigned_app, TInt w)
 
-    | EOp (((K.AddW | K.SubW | K.MultW | K.DivW) as op), w), [ e1; e2 ] when K.is_unsigned w ->
-        let e = mk_op (K.without_wrap op) w in
+    | EOp (((K.AddW | K.SubW | K.MultW | K.DivW) as op), TInt w), [ e1; e2 ] when K.is_unsigned w ->
+        let e = mk_op (K.without_wrap op) (TInt w) in
         let e1 = self#visit_expr env e1 in
         let e2 = self#visit_expr env e2 in
         EApp (e, [ e1; e2 ])
@@ -445,7 +445,7 @@ let constant_fold = object (self)
     in
 
     match e.node, es with
-    | EOp (K.Add, w), [ e1; e2 ] -> (
+    | EOp (K.Add, TInt w), [ e1; e2 ] -> (
         let e1 = self#visit_expr env e1 in
         let e2 = self#visit_expr env e2 in
         let is_int w =
@@ -463,7 +463,7 @@ let constant_fold = object (self)
         | _ -> EApp (e, [ e1; e2 ])
     )
 
-    | EOp (K.Mult, w), [ e1; e2 ] -> (
+    | EOp (K.Mult, TInt w), [ e1; e2 ] -> (
         let e1 = self#visit_expr env e1 in
         let e2 = self#visit_expr env e2 in
         match e1.node, e2.node with
@@ -479,7 +479,7 @@ let constant_fold = object (self)
         | _ -> EApp (e, [ e1; e2 ])
     )
 
-    | EOp (K.Div, w), [ e1; e2 ] -> (
+    | EOp (K.Div, TInt w), [ e1; e2 ] -> (
         let e1 = self#visit_expr env e1 in
         let e2 = self#visit_expr env e2 in
         match e1.node, e2.node with
@@ -493,7 +493,7 @@ let constant_fold = object (self)
         | _ -> EApp (e, [ e1; e2 ])
     )
 
-    | EOp (K.Mod, w), [ e1; e2 ] -> (
+    | EOp (K.Mod, TInt w), [ e1; e2 ] -> (
         let e1 = self#visit_expr env e1 in
         let e2 = self#visit_expr env e2 in
         match e1.node, e2.node with
@@ -1207,7 +1207,7 @@ let rec flag_short_circuit tbl loc t e0 es =
   let lhs0, e0 = hoist_expr loc Unspecified e0 in
   let lhss, es = List.split (List.map (hoist_expr loc Unspecified) es) in
   match e0.node, es, lhss with
-  | EOp ((K.And | K.Or) as op, K.Bool), [ e1; e2 ], [ lhs1; lhs2 ] ->
+  | EOp ((K.And | K.Or) as op, TBool), [ e1; e2 ], [ lhs1; lhs2 ] ->
       (* In Wasm, we automatically inline functions based on their size, so we
        * can't ask the user to rewrite, but it's ok, because it's an expression
        * language, so we can have let-bindings anywhere. *)


### PR DESCRIPTION
Prompted from discussion [here](https://github.com/FStarLang/karamel/pull/737#issuecomment-4355516642).

Question: The op's from Assign onwards are not generated by F* (they are not even in its op type). Are they generated from elsewhere or just internal? Idem for Float types, though these will be added to F*.

