### PR TITLE
Remove unused module aliases (both F* and OCaml files)

### DIFF
--- a/book/tutorial/code/Impl.Bignum.Lemmas.fst
+++ b/book/tutorial/code/Impl.Bignum.Lemmas.fst
@@ -6,12 +6,9 @@ module Impl.Bignum.Lemmas
 /// Let's move lemmas to a separate module. It'll be cleaner!
 
 module B = LowStar.Buffer
-module ST = FStar.HyperStack.ST
-module HS = FStar.HyperStack
 module S = FStar.Seq
 
 module U32 = FStar.UInt32
-module U64 = FStar.UInt64
 
 /// I oftentimes use ``Spec`` to refer to the spec of the current module.
 module Spec = Spec.Bignum

--- a/book/tutorial/code/Impl.Bignum.fst
+++ b/book/tutorial/code/Impl.Bignum.fst
@@ -11,7 +11,6 @@ module HS = FStar.HyperStack
 module S = FStar.Seq
 
 module U32 = FStar.UInt32
-module U64 = FStar.UInt64
 
 /// I oftentimes use ``Spec`` to refer to the spec of the current module.
 module Spec = Spec.Bignum

--- a/krmllib/runtime/WasmSupport.fst
+++ b/krmllib/runtime/WasmSupport.fst
@@ -3,7 +3,6 @@ module WasmSupport
 open FStar.HyperStack.ST
 
 module C = FStar.Int.Cast
-module I64 = FStar.Int64
 module U32 = FStar.UInt32
 module U64 = FStar.UInt64
 module B = LowStar.Buffer

--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -6,7 +6,6 @@
 module CF = CFlat
 module K = Constant
 module LidMap = Idents.LidMap
-module StringMap = Map.Make(String)
 
 open CFlat.Sizes
 open Ast

--- a/lib/CFlatToWasm.ml
+++ b/lib/CFlatToWasm.ml
@@ -8,7 +8,6 @@ open Loc
 module W = Wasm
 module K = Constant
 
-module StringMap = Map.Make(String)
 module StringSet = Set.Make(String)
 
 (******************************************************************************)

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -55,7 +55,6 @@ module DataType = struct
 end
 
 module NameMap = Map.Make(Name)
-module DataTypeMap = Map.Make(DataType)
 module VarSet = Set.Make(Atom)
 module IntSet = Set.Make(Int)
 

--- a/lib/OptimizeWasm.ml
+++ b/lib/OptimizeWasm.ml
@@ -7,8 +7,6 @@
 open Wasm
 open CFlatToWasm
 
-module StringMap = Map.Make(String)
-
 let is_readonly = function
   | Ast.Const _
   | Ast.Load _

--- a/lib/SimplifyMerge.ml
+++ b/lib/SimplifyMerge.ml
@@ -8,7 +8,6 @@ open DeBruijn
 open PrintAst
 
 module S = Set.Make(Atom)
-module M = Map.Make(Atom)
 
 let debug = false
 

--- a/test/Rustpropererasure.fst
+++ b/test/Rustpropererasure.fst
@@ -1,7 +1,6 @@
 module Rustpropererasure
 open FStar.HyperStack.ST
 
-module G = FStar.Ghost
 module U32 = FStar.UInt32
 
 noeq type slice (t: Type0) : Type0 = { len: U32.t ; ptr: ref t }

--- a/test/rust-propererasure-bundle/Base.fst
+++ b/test/rust-propererasure-bundle/Base.fst
@@ -1,9 +1,7 @@
 module Base
 open FStar.HyperStack.ST
 
-module G = FStar.Ghost
 module U32 = FStar.UInt32
-module C = C
 
 noeq type slice (t: Type0) : Type0 = { len: U32.t ; ptr: ref t }
 


### PR DESCRIPTION
With the help of remove_all_unused_opens.sh in F*.