### PR TITLE
Update dist + add a daily workflow for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
 
       # Install karamel deps
       - run: opam install --deps-only karamel/karamel.opam
-      - run: opam install ctypes ctypes-foreign # not in deps?
 
       - name: Build EverParse opam dependencies
         run: |

--- a/.github/workflows/sync-krmllib-dist.yml
+++ b/.github/workflows/sync-krmllib-dist.yml
@@ -1,0 +1,83 @@
+name: Sync krmllib/dist
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sync-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Z3 with script
+        run: |
+          wget https://raw.githubusercontent.com/FStarLang/FStar/refs/heads/master/.scripts/get_fstar_z3.sh -O get_fstar_z3.sh
+          chmod +x get_fstar_z3.sh
+          ./get_fstar_z3.sh /usr/local/bin
+
+      - name: Setup ocaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+           ocaml-compiler: 5.3.0
+
+      - uses: actions/checkout@master
+        with:
+          path: karamel
+
+      - run: opam update
+      - run: opam pin -n fstar git+https://github.com/FStarLang/FStar#fstar1
+      - run: opam install fstar
+      - run: opam install --deps-only karamel/karamel.opam
+
+      - name: Build
+        working-directory: karamel
+        run: |
+          eval $(opam env)
+          export OCAMLRUNPARAM=b
+          make -kj$(nproc)
+
+      - name: Check for dist changes
+        id: diff
+        working-directory: karamel
+        run: |
+          if git diff --quiet krmllib/dist; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update PR if dist changed
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: karamel
+        env:
+          DZOMO_GITHUB_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto/sync-krmllib-dist"
+          git config user.name "Dzomo, the Everest Yak"
+          git config user.email "24394600+dzomo@users.noreply.github.com"
+          # Use the PAT for push so the resulting PR triggers CI
+          git remote set-url origin "https://$DZOMO_GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
+
+          # Skip push if the existing branch already has identical dist contents
+          if git fetch origin "$BRANCH" 2>/dev/null &&
+             git diff --quiet "origin/$BRANCH" -- krmllib/dist; then
+            echo "Branch $BRANCH already has the same dist contents, nothing to do."
+            exit 0
+          fi
+
+          git checkout -B "$BRANCH"
+          git add krmllib/dist
+          git commit -m "Regenerate krmllib/dist"
+          git push -f origin "$BRANCH"
+          # Only create a PR if one doesn't already exist for this branch
+          if ! gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
+            gh pr create \
+              --title "Regenerate krmllib/dist" \
+              --body "Automated update: \`make\` produced changes in \`krmllib/dist\`." \
+              --head "$BRANCH"
+          fi

--- a/krmllib/dist/generic/FStar_Order.c
+++ b/krmllib/dist/generic/FStar_Order.c
@@ -109,13 +109,13 @@ FStar_Order_order FStar_Order_lex(FStar_Order_order o1, FStar_Order_order (*o2)(
 
 FStar_Order_order FStar_Order_order_from_int(krml_checked_int_t i)
 {
-  if (Prims_op_LessThan(i, (krml_checked_int_t)0))
+  if (Prims_op_LessThan(i, 0))
   {
     return FStar_Order_Lt;
   }
   else
   {
-    return i == (krml_checked_int_t)0 ? FStar_Order_Eq : FStar_Order_Gt;
+    return i == 0 ? FStar_Order_Eq : FStar_Order_Gt;
   }
 }
 
@@ -125,15 +125,15 @@ krml_checked_int_t FStar_Order_int_of_order(FStar_Order_order uu___)
   {
     case FStar_Order_Lt:
       {
-        return (krml_checked_int_t)-1;
+        return -1;
       }
     case FStar_Order_Eq:
       {
-        return (krml_checked_int_t)0;
+        return 0;
       }
     case FStar_Order_Gt:
       {
-        return (krml_checked_int_t)1;
+        return 1;
       }
     default:
       {


### PR DESCRIPTION
This will open a PR whenever there is a diff. CI should run on the PR (github disables that by default, but using DZOMO_GITHUB_TOKEN should make it kick in). The existing PR is updated if it is unmerged and the dist changed again.

Knowing actions, it's possible this fails in some weird way. I'll fix if so. It's hard to tell before deploying.