### PR TITLE
Fix UInt8/UInt16 masking: switch scrutinee, ETernary, ECast

### DIFF
--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -363,6 +363,13 @@ and mk_arith env e =
          that every subexpression operates over unsigned int until the final
          cast, or until a mask is needed to preserve semantics. *)
       mk_expr env false false e, true, false (* C++: a constant that is wider than the intended type, but in an initializer list, is ok *)
+  | ETernary (c, t, f) ->
+      (* Recurse into branches so that non-atomic arithmetic is not hidden
+         behind a ternary marked as "atomic". *)
+      let c = mk_expr env false false c in
+      let t, a1, w1 = mk_arith env t in
+      let f, a2, w2 = mk_arith env f in
+      CStar.Ternary (c, t, f), a1 && a2, w1 || w2
   | _ ->
       (* Something else. Who knows? Maybe a function call, a field reference, a
          variable, a global... which will be upcast into `int`, which is *not*
@@ -454,7 +461,17 @@ and mk_expr env in_stmt under_initializer_list e =
          scalar type in C that is supported by C's equality comparison. *)
       CStar.Op (K.op_of_poly_comp c)
   | ECast (e, t) ->
-      CStar.Cast (mk_expr env false e, mk_type env t)
+      (* When the source is UInt8/UInt16 and contains arithmetic, the widened
+         result may have extra bits. We must mask before casting to a wider
+         type, otherwise the junk bits are preserved. *)
+      begin match e.typ with
+      | TInt w when w = K.UInt8 || w = K.UInt16 ->
+          let e', is_atomic, _ = mk_arith env e in
+          let e' = if is_atomic then e' else mask w e' in
+          CStar.Cast (e', mk_type env t)
+      | _ ->
+          CStar.Cast (mk_expr env false e, mk_type env t)
+      end
   | EAbort (t, s) ->
       let t = match t with Some t -> t | None -> e.typ in
       CStar.EAbort (mk_type env t, Option.value ~default:"" s)
@@ -702,7 +719,16 @@ and mk_stmts env e ret_type =
           | [] -> None
           | _ -> failwith "impossible"
         in
-        env, CStar.Switch (mk_expr env false false e0,
+        (* In C, the scrutinee is widened to at least int. Since U8/U16
+           have defined overflow, we must mask the extra bits away if the
+           scrutinee is of that type. See https://github.com/FStarLang/karamel/issues/707. *)
+        let scrutinee = match e0.typ with
+          | TInt w when w = K.UInt8 || w = K.UInt16 ->
+              let e, is_atomic, _ = mk_arith env e0 in
+              if is_atomic then e else mask w e
+          | _ -> mk_expr env false false e0
+        in
+        env, CStar.Switch (scrutinee,
           List.map (fun (lid, e) ->
             (match lid with
             | SConstant k -> `Int k

--- a/test/SmallIntCast.fst
+++ b/test/SmallIntCast.fst
@@ -1,0 +1,35 @@
+/// Regression test: ECast on UInt8/UInt16 wrapping arithmetic
+/// doesn't mask before widening, leaking overflow bits.
+module SmallIntCast
+
+open FStar.UInt8
+module U32 = FStar.UInt32
+module Cast = FStar.Int.Cast
+
+/// Cast wrapping addition to UInt32.
+/// F*: (200 + 56) mod 256 = 0, cast to UInt32 => 0ul.
+let cast_add_to_u32 (a b: UInt8.t) : U32.t =
+  Cast.uint8_to_uint32 (a +%^ b)
+
+/// Cast wrapping subtraction to UInt32.
+/// F*: (0 - 1) mod 256 = 255, cast to UInt32 => 255ul.
+let cast_sub_to_u32 (a b: UInt8.t) : U32.t =
+  Cast.uint8_to_uint32 (a -%^ b)
+
+/// Cast wrapping multiplication to UInt32.
+/// F*: (128 * 3) mod 256 = 128, cast to UInt32 => 128ul.
+let cast_mul_to_u32 (a b: UInt8.t) : U32.t =
+  Cast.uint8_to_uint32 (a *%^ b)
+
+/// Cast BNot to UInt32.
+/// F*: lognot 0x0F = 0xF0 = 240, cast to UInt32 => 240ul.
+let cast_bnot_to_u32 (x: UInt8.t) : U32.t =
+  Cast.uint8_to_uint32 (UInt8.lognot x)
+
+let main () : FStar.Int32.t =
+  if cast_add_to_u32 200uy 56uy = 0ul
+  && cast_sub_to_u32 0uy 1uy = 255ul
+  && cast_mul_to_u32 128uy 3uy = 128ul
+  && cast_bnot_to_u32 0x0Fuy = 240ul
+  then 0l
+  else 1l

--- a/test/SmallIntSwitch.fst
+++ b/test/SmallIntSwitch.fst
@@ -1,0 +1,37 @@
+/// Regression test for karamel issue #707.
+/// Tests that UInt8/UInt16 switch scrutinee is correctly masked
+/// after wrapping arithmetic, so the right branch is taken.
+module SmallIntSwitch
+
+open FStar.UInt8
+
+/// Match on wrapping addition that overflows 8 bits.
+/// F*: (200 + 56) mod 256 = 0, so must match 0uy and return 10.
+let via_switch_add (a b: UInt8.t) : FStar.UInt32.t =
+  match (a +%^ b) with
+  | 0uy -> 10ul
+  | 1uy -> 20ul
+  | _   -> 30ul
+
+/// Match on wrapping subtraction that underflows.
+/// F*: (0 - 1) mod 256 = 255, so must match 255uy and return 40.
+let via_switch_sub (a b: UInt8.t) : FStar.UInt32.t =
+  match (a -%^ b) with
+  | 0uy   -> 50ul
+  | 255uy -> 40ul
+  | _     -> 60ul
+
+/// Match on wrapping multiplication.
+/// F*: (128 * 3) mod 256 = 384 mod 256 = 128, so must match 128uy.
+let via_switch_mul (a b: UInt8.t) : FStar.UInt32.t =
+  match (a *%^ b) with
+  | 0uy   -> 70ul
+  | 128uy -> 80ul
+  | _     -> 90ul
+
+let main () : FStar.Int32.t =
+  if via_switch_add 200uy 56uy = 10ul
+  && via_switch_sub 0uy 1uy = 40ul
+  && via_switch_mul 128uy 3uy = 80ul
+  then 0l
+  else 1l

--- a/test/SmallIntTernary.fst
+++ b/test/SmallIntTernary.fst
@@ -1,0 +1,45 @@
+/// Regression test: ETernary wrapping UInt8 arithmetic hides
+/// non-atomic expression from mk_arith, causing missing mask.
+/// The ternary is marked "atomic" by the catch-all in mk_arith,
+/// so consumers (switch, comparisons) skip the mask.
+module SmallIntTernary
+
+open FStar.UInt8
+
+/// Switch on a ternary whose "then" branch is wrapping addition.
+/// F*: flag=true, a=200, b=56 => (200+56) mod 256 = 0, match 0uy => 10.
+let switch_on_ternary (flag: bool) (a b: UInt8.t) : FStar.UInt32.t =
+  match (if flag then (a +%^ b) else 0uy) with
+  | 0uy -> 10ul
+  | 1uy -> 20ul
+  | _   -> 30ul
+
+/// Comparison on a ternary whose "then" branch is wrapping addition.
+/// F*: flag=true, a=200, b=56 => (200+56) mod 256 = 0 = 0uy => true.
+let cmp_on_ternary (flag: bool) (a b: UInt8.t) : bool =
+  (if flag then (a +%^ b) else 1uy) = 0uy
+
+/// BNot inside ternary, feeding a switch.
+/// F*: flag=true, x=0x0Fuy => lognot 0x0F = 0xF0 = 240, match 240uy => 99.
+let switch_ternary_bnot (flag: bool) (x: UInt8.t) : FStar.UInt32.t =
+  match (if flag then (UInt8.lognot x) else 0uy) with
+  | 0uy   -> 77ul
+  | 240uy -> 99ul
+  | _     -> 88ul
+
+/// Nested ternary: both branches are arithmetic.
+/// F*: f1=true, f2=false, a=200, b=56, c=100, d=200 =>
+///     inner = (100+200) mod 256 = 44. match 44uy => 55.
+let switch_nested_ternary (f1 f2: bool) (a b c d: UInt8.t) : FStar.UInt32.t =
+  match (if f1 then (if f2 then (a +%^ b) else (c +%^ d)) else 0uy) with
+  | 0uy  -> 33ul
+  | 44uy -> 55ul
+  | _    -> 66ul
+
+let main () : FStar.Int32.t =
+  if switch_on_ternary true 200uy 56uy = 10ul
+  && cmp_on_ternary true 200uy 56uy = true
+  && switch_ternary_bnot true 0x0Fuy = 99ul
+  && switch_nested_ternary true false 200uy 56uy 100uy 200uy = 55ul
+  then 0l
+  else 1l


### PR DESCRIPTION
Three issues:
1- The ESwitch case passed the scrutinee through mk_expr, bypassing
   mk_arith masking.
2- mk_arith's catch-all marked ETernary as atomic, hiding non-atomic
   arithmetic branches from consumers (switch, comparisons).
3- ECast applied the cast to the widened uint32 value without masking,
   leaking overflow bits on widening casts.

Fix: for UInt8/UInt16 switch scrutinees, route through mk_arith and mask non-atomic results. Add an ETernary case to mk_arith that recurses into both branches, returning is_atomic only when both are atomic. For ECast, route UInt8/UInt16 sources through mk_arith and mask before casting.

Add SmallIntSwitch.fst, SmallIntTernary.fst, SmallIntCast.fst regression tests.

Fixes #707

--

Hi Jonathan, this is coauthored with Claude. It fixes #707 (which is legit) and a few other variants. The three tests fail before this patch. I'm not sure the style of the patch is that pleasant, since it seems easy to forget about this mk_arith dance and reintroduce variants of this bug later.