### PR TITLE
Generating C compound assignments (x += 2, etc)

### DIFF
--- a/lib/C11.ml
+++ b/lib/C11.ml
@@ -52,7 +52,7 @@ and expr =
   | Member of expr * expr
   | MemberP of expr * expr
   | Assign of expr * expr
-    (** not covering *=, +=, etc. *)
+  | CompoundAssign of expr * K.op * expr (* x op= y, op is binary. *)
   | Call of expr * expr list
   | Name of ident
   | Cast of type_name * expr

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -46,10 +46,13 @@ let is_compoundable : K.op -> bool = function
      evaluation *)
 let mk_assign (lhs : C11.expr) (rhs : C11.expr) : C11.expr =
   match rhs with
+  | Op2 (Add, e2, Cast (_, Constant (_, "1")))
   | Op2 (Add, e2, Constant (_, "1")) when e2 = lhs ->
     Op1 (PostIncr, lhs)
+  | Op2 (Add, Cast (_, Constant (_, "1")), e2)
   | Op2 (Add, Constant (_, "1"), e2) when e2 = lhs ->
     Op1 (PostIncr, lhs)
+  | Op2 (Sub, e2, Cast (_, Constant (_, "1")))
   | Op2 (Sub, e2, Constant (_, "1")) when e2 = lhs ->
     Op1 (PostDecr, lhs)
   | Op2 (op, e2, e3) when is_compoundable op && e2 = lhs ->

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -32,9 +32,28 @@ let is_compoundable : K.op -> bool = function
   | BOr | BAnd | BXor | BShiftL | BShiftR -> true
   | _ -> false
 
+(* returns true when expr is definitely pure *)
+let rec is_pure : C11.expr -> bool = function
+  | Assign _ | CompoundAssign _ | Call _ | Stmt _
+  | Member _ | MemberP _ -> false (* Unsure what these are *)
+
+  | Name _ | Literal _ | Constant _ | Bool _
+  | Sizeof _ | CompoundLiteral _ | Type _
+  | CxxInitializerList _ -> true
+
+  | Op1 (_, e) -> is_pure e
+  | Op2 (_, e1, e2) -> is_pure e1 && is_pure e2
+  | Index (e1, e2) -> is_pure e1 && is_pure e2
+  | Deref e -> is_pure e
+  | Address e -> is_pure e
+  | Cast (_, e) -> is_pure e
+  | MemberAccess (e, _) -> is_pure e
+  | MemberAccessPointer (e, _) -> is_pure e
+  | InlineComment (_, e, _) -> is_pure e
+  | Ternary (e1, e2, e3) -> is_pure e1 && is_pure e2 && is_pure e3
+
 (* Tries to make compound assignments when possible.
    Assumptions:
-   - lhs is pure, so removing one occurrence has no effect on semantics.
    - The result is always used in statement context (discarded value), so
      PostIncr vs PreIncr does not matter.
 
@@ -46,6 +65,10 @@ let is_compoundable : K.op -> bool = function
      evaluation *)
 let mk_assign (lhs : C11.expr) (rhs : C11.expr) : C11.expr =
   match rhs with
+  (* We don't really generate impure LHS of assignments,
+     but it doesn't hurt to be defensive. *)
+  | _ when not (is_pure lhs) -> Assign (lhs, rhs)
+
   | Op2 (Add, e2, Cast (_, Constant (_, "1")))
   | Op2 (Add, e2, Constant (_, "1")) when e2 = lhs ->
     Op1 (PostIncr, lhs)

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -21,6 +21,44 @@ let cmul x y =
   | _ -> C.Op2 (K.Mult, x, y)
 
 let is_array = function Array _ -> true | _ -> false
+
+let is_commutative : K.op -> bool = function
+  | Add | Mult
+  | BOr | BAnd | BXor -> true
+  | _ -> false
+
+let is_compoundable : K.op -> bool = function
+  | Add | Sub | Mult | Div | Mod
+  | BOr | BAnd | BXor | BShiftL | BShiftR -> true
+  | _ -> false
+
+(* Tries to make compound assignments when possible.
+   Assumptions:
+   - lhs is pure, so removing one occurrence has no effect on semantics.
+   - The result is always used in statement context (discarded value), so
+     PostIncr vs PreIncr does not matter.
+
+   C standard §6.5.16.2:
+     A compound assignment of the form E1 op = E2 is equivalent to the simple
+     assignment expression E1 = E1 op (E2), except that the lvalue E1 is
+     evaluated only once, and with respect to an indeterminately-sequenced
+     function call, the operation of a compound assignment is a single
+     evaluation *)
+let mk_assign (lhs : C11.expr) (rhs : C11.expr) : C11.expr =
+  match rhs with
+  | Op2 (Add, e2, Constant (_, "1")) when e2 = lhs ->
+    Op1 (PostIncr, lhs)
+  | Op2 (Add, Constant (_, "1"), e2) when e2 = lhs ->
+    Op1 (PostIncr, lhs)
+  | Op2 (Sub, e2, Constant (_, "1")) when e2 = lhs ->
+    Op1 (PostDecr, lhs)
+  | Op2 (op, e2, e3) when is_compoundable op && e2 = lhs ->
+    CompoundAssign (lhs, op, e3)
+  | Op2 (op, e2, e3) when e3 = lhs && is_compoundable op && is_commutative op ->
+    CompoundAssign (lhs, op, e2)
+  | _ ->
+    Assign (lhs, rhs)
+
 let is_var = function Var _ -> true | _ -> false
 let is_call = function
   | Call (Qualified (_, s), _) ->
@@ -816,12 +854,6 @@ and mk_stmt m (stmt: stmt): C.stmt list =
   | Assign (BufRead _, _, (Any | Cast (Any, _))) ->
       []
 
-  | Assign (Var x, _, Call (Op K.Add, [ Var y; Constant (_, "1") ])) when x = y ->
-      [ Expr (Op1 (PostIncr, Name x)) ]
-
-  | Assign (Var x, _, Call (Op K.Sub, [ Var y; Constant (_, "1") ])) when x = y ->
-      [ Expr (Op1 (PostDecr, Name x)) ]
-
   | Assign (e1, t, BufCreate (Eternal, init, size)) ->
       let v = assert_var m e1 in
       (* Evil bug:
@@ -856,13 +888,13 @@ and mk_stmt m (stmt: stmt): C.stmt list =
       failwith "TODO"
 
   | Assign (e1, _, e2) ->
-      [ Expr (Assign (mk_expr m e1, mk_expr m e2)) ]
+      [ Expr (mk_assign (mk_expr m e1) (mk_expr m e2)) ]
 
   | BufWrite (_, _, (Any | Cast (Any, _))) ->
       []
 
   | BufWrite (e1, e2, e3) ->
-      [ Expr (Assign (mk_index m e1 e2, mk_expr m e3)) ]
+      [ Expr (mk_assign (mk_index m e1 e2) (mk_expr m e3)) ]
 
   | BufBlit (t, e1, e2, e3, e4, e5) ->
       let dest = match e4 with

--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -272,6 +272,12 @@ and p_expr' curr = function
       let e1 = p_expr' left e1 in
       let e2 = p_expr' right e2 in
       paren_if curr mine (group (e1 ^/^ equals) ^^ jump e2)
+  | CompoundAssign (e1, op, e2) ->
+      let mine, left, right = 14, 13, 14 in
+      let right = defeat_Wparentheses op e2 right in
+      let e1 = p_expr' left e1 in
+      let e2 = p_expr' right e2 in
+      paren_if curr mine (group (e1 ^/^ print_op op ^^ equals) ^^ jump e2)
   | Call (e, es) ->
       let mine, left, arg = 1, 1, 14 in
       let e = p_expr' left e in

--- a/test/pulse/CompoundAssignment.expected.c
+++ b/test/pulse/CompoundAssignment.expected.c
@@ -1,0 +1,36 @@
+/* krml header omitted for test repeatability */
+
+
+#include "CompoundAssignment.h"
+
+void CompoundAssignment_test(uint32_t *x)
+{
+  (*x)++;
+  (*x)++;
+  (*x)--;
+  *x = 1U - *x;
+  *x *= 2U;
+  *x *= 2U;
+  *x /= 2U;
+  *x %= 2U;
+}
+
+void CompoundAssignment_test2(uint32_t *x)
+{
+  *x = 2U / *x;
+}
+
+void CompoundAssignment_test3(uint32_t *x)
+{
+  *x = 2U % *x;
+}
+
+void CompoundAssignment_test_bitwise(uint32_t *x)
+{
+  *x &= 0x0FU;
+  *x |= 0xF0U;
+  *x ^= 0xAAU;
+  *x <<= 2U;
+  *x >>= 1U;
+}
+

--- a/test/pulse/CompoundAssignment.fst
+++ b/test/pulse/CompoundAssignment.fst
@@ -1,0 +1,47 @@
+module CompoundAssignment
+
+#lang-pulse
+open Pulse
+
+module U32 = FStar.UInt32
+
+fn test (x : ref U32.t)
+  preserves live x
+{
+  open U32;
+  x := !x +%^ 1ul;
+  x := 1ul +%^ !x;
+  x := !x -%^ 1ul;
+  x := 1ul -%^ !x;
+  x := !x *%^ 2ul;
+  x := 2ul *%^ !x;
+  x := !x /^ 2ul;
+  x := !x %^ 2ul;
+}
+
+fn test2 (x : ref U32.t)
+  requires pure (!x <> 0ul)
+  preserves live x
+{
+  open U32;
+  x := 2ul /^ !x;
+}
+
+fn test3 (x : ref U32.t)
+  requires pure (!x <> 0ul)
+  preserves live x
+{
+  open U32;
+  x := 2ul %^ !x;
+}
+
+fn test_bitwise (x : ref U32.t)
+  preserves live x
+{
+  open U32;
+  x := !x &^ 0x0Ful;
+  x := !x |^ 0xF0ul;
+  x := !x ^^ 0xAAul;
+  x := shift_left (!x) 2ul;
+  x := shift_right (!x) 1ul;
+}

--- a/test/pulse/Makefile
+++ b/test/pulse/Makefile
@@ -15,3 +15,6 @@ $(OUTPUT_DIR)/Example_Slice.c: $(addprefix $(OUTPUT_DIR)/,\
 $(OUTPUT_DIR)/Example_Unreachable.c: $(addprefix $(OUTPUT_DIR)/,\
 	FStar_Pervasives.krml \
 	FStar_Pervasives_Native.krml)
+
+# Inline enough so the augmented assignments actually kick in
+$(OUTPUT_DIR)/CompoundAssignment.c: KRML_FLAGS += -faggressive-inlining


### PR DESCRIPTION
Directly at the level of C11, with a conservative check that the expression is syntactically equal on the LHS and RHS. This way we will not silently drop any inserted casts. The type promotion semantics for a compound assignment and its plain version also match.