### PR TITLE
Inlining: fix bug about loop guards

### DIFF
--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -89,10 +89,28 @@ class ['self] safe_use lvalue = object (self: 'self)
      *every* path in the control-flow is safe. *)
   method! visit_EIfThenElse env e _ _ = self#sequential env e None
   method! visit_ESwitch env e _ = self#sequential env e None
-  method! visit_EWhile env e _ = self#sequential env e None
-  method! visit_EFor env _ e _ _ _ = self#sequential env e None
   method! visit_EMatch env _ e _ = self#sequential env e None
   method! visit_ESequence env es = self#sequential env (List.hd es) None
+
+  (* Loops are more complicated. We cannot just use self#sequential since we
+     have to consider that the bodies run multiple times, and therefore we must
+     still look at the rest of the body even after first use of a variable.
+     Example:
+
+      int x = a[i];
+      while (...) {
+        b[j] = x;
+        a[foo] ...;
+      }
+
+    inlining x ~> a[i] into the loop body is in general not equivalent: b could
+    alias to a, and writes to a[foo] could change the value of a[i] across
+    iterations.  This also applies to the condition: we cannot inline into the
+    condition of a while loop (See InlineLoopCond.fst testcase). The only thing
+    we do allow is inlining into the initializer of a for loop, since it is only
+    executed once. *)
+  method! visit_EWhile _ _ _ = Unsafe
+  method! visit_EFor env _ e_init _ _ _ = self#sequential env e_init None
 end
 
 let safe_readonly_use lvalue e =
@@ -142,8 +160,8 @@ let use_mark_to_inline_temporaries = object (self)
        ) &&
         (v = AtMost 1 && (
           let lvalue = Structs.will_be_lvalue e1 in
-          is_readonly_c_expression e1 &&
-          safe_readonly_use lvalue e2 ||
+          (is_readonly_c_expression e1 &&
+           safe_readonly_use lvalue e2) ||
           safe_pure_use lvalue e2
         ) ||
         is_readonly_and_variable_free_c_expression e1 && not b.node.mut)

--- a/test/pulse/.gitignore
+++ b/test/pulse/.gitignore
@@ -1,1 +1,2 @@
+local-fstar
 _output

--- a/test/pulse/Inline.expected.c
+++ b/test/pulse/Inline.expected.c
@@ -1,0 +1,60 @@
+/* krml header omitted for test repeatability */
+
+
+#include "Inline.h"
+
+uint32_t Inline_basic(uint32_t (*i)(void))
+{
+  return i();
+}
+
+uint32_t Inline_chain(uint32_t (*i)(void), uint32_t (*f)(uint32_t x0))
+{
+  return f(i());
+}
+
+void Inline_chain_ignore(uint32_t (*i)(void), uint32_t (*f)(uint32_t x0))
+{
+  KRML_HOST_IGNORE(f(i()));
+}
+
+void Inline_chain_ignore_(uint32_t (*i)(void), uint32_t (*f)(uint32_t x0))
+{
+  uint32_t x = f(i());
+  KRML_MAYBE_UNUSED_VAR(x);
+}
+
+uint32_t Inline_chain_ignore__(uint32_t (*i)(void), uint32_t (*f)(uint32_t x0))
+{
+  uint32_t uu____0 = f(i());
+  Inline_g();
+  return uu____0;
+}
+
+uint32_t Inline_tst(uint32_t shared)
+{
+  uint32_t uu____0 = shared / 100U;
+  uint32_t i = 0U;
+  uint32_t __anf00 = i;
+  bool cond = __anf00 < uu____0;
+  while (cond)
+  {
+    uint32_t __anf0 = i;
+    i = __anf0 + 1U;
+    uint32_t __anf00 = i;
+    cond = __anf00 < uu____0;
+  }
+  return 1U;
+}
+
+uint32_t Inline_order(uint32_t (*f)(void))
+{
+  uint32_t uu____0 = f();
+  return uu____0 + Inline_g();
+}
+
+uint32_t Inline_test_array_access(uint32_t *a, size_t *r)
+{
+  return a[*r];
+}
+

--- a/test/pulse/Inline.fst
+++ b/test/pulse/Inline.fst
@@ -1,0 +1,94 @@
+module Inline
+
+#lang-pulse
+open Pulse
+
+assume val g :  fn (_ : unit) returns UInt32.t
+
+fn basic (i : unit -> fn returns UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__ = i (); // This name triggers inlining.
+  uu__
+}
+
+fn chain (i : unit -> fn returns UInt32.t)
+  (f : UInt32.t -> fn returns UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__ = i ();
+  f uu__
+}
+
+fn chain_ignore (i : unit -> fn returns UInt32.t)
+  (f : UInt32.t -> fn returns UInt32.t)
+{
+  open FStar.UInt32;
+  let uu__ = i ();
+  let _ = f uu__;
+  ()
+}
+
+fn chain_ignore' (i : unit -> fn returns UInt32.t)
+  (f : UInt32.t -> fn returns UInt32.t)
+{
+  open FStar.UInt32;
+  let uu__ = i ();
+  let x = f uu__; (* x should remain in the C code *)
+  ()
+}
+
+fn chain_ignore'' (i : unit -> fn returns UInt32.t)
+  (f : UInt32.t -> fn returns UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__ = i ();
+  let uu__ = f uu__;
+  (* ^ should remain since we call g() after *)
+  g();
+  uu__
+}
+
+fn tst (shared : UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__k = shared /^ 100ul;
+  let mut i = 0ul;
+  while (!i <^ uu__k)
+    invariant live i
+  {
+    i := !i +^ 1ul;
+  };
+  1ul
+}
+
+fn order (f : unit -> fn returns UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  (* The call to g() can be inlined in the sum,
+     but not the call to f(). There is no guaranteed
+     ordering if we have f() + g(). *)
+  let uu__1 = f ();
+  let uu__2 = g ();
+  uu__1 +%^ uu__2
+}
+
+fn test_array_access
+  (a : larray UInt32.t 200)
+  (r : ref SizeT.t)
+  preserves live a
+  preserves r |-> 23sz
+  returns UInt32.t
+{
+  Pulse.Lib.Array.pts_to_len a;
+  open FStar.SizeT;
+  // g ();
+  let uu__ = !r;
+  let uu__ = a.(uu__);
+  uu__
+}

--- a/test/pulse/InlineAcrossIf.expected.c
+++ b/test/pulse/InlineAcrossIf.expected.c
@@ -1,0 +1,59 @@
+/* krml header omitted for test repeatability */
+
+
+#include "InlineAcrossIf.h"
+
+uint32_t InlineAcrossIf_basic(bool b, uint32_t (*i)(void))
+{
+  uint32_t uu____0 = i();
+  uint32_t y = b ? 2U : 3U;
+  return uu____0 + y;
+}
+
+uint32_t InlineAcrossIf_basic2(bool b, uint32_t (*i)(void), uint32_t x, uint32_t y)
+{
+  uint32_t uu____0 = i();
+  uint32_t y1 = b ? x : y;
+  return uu____0 + y1;
+}
+
+uint32_t InlineAcrossIf_basic3(bool b, uint32_t x)
+{
+  uint32_t uu____0 = x;
+  return b ? uu____0 + 1U : uu____0 + 2U;
+}
+
+uint32_t InlineAcrossIf_should_not_inline1(bool b, uint32_t (*i1)(void), uint32_t (*i2)(void))
+{
+  uint32_t uu____0 = i1();
+  uint32_t y;
+  if (b)
+    y = i2();
+  else
+    y = 0U;
+  return uu____0 + y;
+}
+
+uint32_t InlineAcrossIf_should_not_inline2(bool b, uint32_t (*i1)(void), uint32_t (*i2)(void))
+{
+  uint32_t uu____0 = i1();
+  uint32_t y;
+  if (b)
+    y = 0U;
+  else
+    y = i2();
+  return uu____0 + y;
+}
+
+uint32_t InlineAcrossIf_should_not_inline3(bool b, uint32_t (*i1)(void), uint32_t (*i2)(void))
+{
+  KRML_MAYBE_UNUSED_VAR(b);
+  uint32_t uu____0 = i1();
+  uint32_t y;
+  if (i2() == 0U)
+    y = 0U;
+  else
+    y = 1U;
+  return uu____0 + y;
+}
+

--- a/test/pulse/InlineAcrossIf.fst
+++ b/test/pulse/InlineAcrossIf.fst
@@ -1,0 +1,67 @@
+module InlineAcrossIf
+
+#lang-pulse
+open Pulse
+
+fn basic (b : bool) (i : unit -> fn returns UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__ = i (); // This name triggers inlining.
+  let y = (if b then 2ul else 3ul);
+  uu__ +%^ y
+}
+
+fn basic2 (b : bool) (i : unit -> fn returns UInt32.t)
+  (x y : UInt32.t)
+  returns UInt32.t
+{
+  (* This can inline, x and y are local pure variables. *)
+  open FStar.UInt32;
+  let uu__ = i ();
+  let y = (if b then x else y);
+  uu__ +%^ y
+}
+
+fn basic3 (b : bool)
+  (x : UInt32.t)
+  returns UInt32.t
+{
+  (* This could inline, even if uu__ is used "twice", since
+  only one branch is executed. However karamel gates inling
+  on "AtMost 1" (syntactic) uses, so it won't inline. *)
+  open FStar.UInt32;
+  let uu__ = x;
+  let y = (if b then uu__ +%^ 1ul else uu__ +%^ 2ul);
+  y
+}
+
+fn should_not_inline1 (b : bool)
+  (i1 i2 : unit -> Tot UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__ = i1 ();
+  let y = (if b then i2 () else 0ul);
+  uu__ +%^ y;
+}
+
+fn should_not_inline2 (b : bool)
+  (i1 i2 : unit -> Tot UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__ = i1 ();
+  let y = (if b then 0ul else i2());
+  uu__ +%^ y;
+}
+
+fn should_not_inline3 (b : bool)
+  (i1 i2 : unit -> Tot UInt32.t)
+  returns UInt32.t
+{
+  open FStar.UInt32;
+  let uu__ = i1 ();
+  let y = (if i2() = 0ul then 0ul else 1ul);
+  uu__ +%^ y;
+}

--- a/test/pulse/InlineLoopCond.expected.c
+++ b/test/pulse/InlineLoopCond.expected.c
@@ -1,0 +1,25 @@
+/* krml header omitted for test repeatability */
+
+
+#include "InlineLoopCond.h"
+
+uint32_t InlineLoopCond_test(uint32_t (*f)(void))
+{
+  uint32_t uu____0 = f();
+  while (uu____0 != 0U)
+  {
+
+  }
+  return 0U;
+}
+
+uint32_t InlineLoopCond_test_ok(uint32_t x)
+{
+  uint32_t uu____0 = x;
+  while (uu____0 != 0U)
+  {
+
+  }
+  return 0U;
+}
+

--- a/test/pulse/InlineLoopCond.fst
+++ b/test/pulse/InlineLoopCond.fst
@@ -1,0 +1,27 @@
+module InlineLoopCond
+
+#lang-pulse
+open Pulse
+
+fn test (f : unit -> fn returns UInt32.t)
+  returns UInt32.t
+{
+  let uu__  = f ();
+  (* Intentionally possibly-infinite loop. The call above
+  cannot be inlined into the condition. *)
+  while (uu__ <> 0ul) {
+    ()
+  };
+  0ul
+}
+
+fn test_ok (x : UInt32.t)
+  returns UInt32.t
+{
+  (* This one could be inlined (it's not at the moment) *)
+  let uu__  = x;
+  while (uu__ <> 0ul) {
+    ()
+  };
+  0ul
+}

--- a/test/pulse/refresh.sh
+++ b/test/pulse/refresh.sh
@@ -2,14 +2,19 @@
 
 # Refresh the outputs from F* nightly.
 
-curl -L https://aka.ms/install-fstar | bash -s -- --nightly --dest local-fstar --no-link
-cleanup () {
-	rm -rf local-fstar
-}
-trap cleanup EXIT ERR
+if ! [ -d local-fstar ]; then
+  curl -L https://aka.ms/install-fstar | bash -s -- --nightly --dest local-fstar --no-link
+fi
 
-FSTAR_EXE=$(pwd)/local-fstar/bin/fstar.exe make clean
-FSTAR_EXE=$(pwd)/local-fstar/bin/fstar.exe make -j$(nproc) accept
+# Invalidate existing karamel files
+touch -c _output/*.krml
+FSTAR_EXE=$(pwd)/local-fstar/bin/fstar.exe make -j$(nproc) accept -k
+RES=$?
 
-echo "Done!"
-exit 0
+if [ $RES -eq 0 ]; then
+  echo "Done!"
+  exit 0
+else
+  echo "error: there were some failures regenerating the expected C files" >&2
+  exit 1
+fi


### PR DESCRIPTION
This first fixes a [critical bug](https://github.com/FStarLang/karamel/commit/43eb6206bb1f91f0c7594a6d1e2a6271d50b3ece) and then improves inlining to consider the alternative behavior of if/ternary/match/switch, and also sequences. This second patch is worth a skeptic look to make sure I'm not misunderstanding the use analysis.

The first fix decreases output quality slightly when the expression to inline is in fact pure, I will try to improve that later.