### PR TITLE
PrintC: fix associativity for +

### DIFF
--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -170,7 +170,7 @@ and prec_of_op2 op =
   let open Constant in
   match op with
   | AddW | SubW | MultW | DivW -> failwith "[prec_of_op]: should've been desugared"
-  | Add -> 4, 4, 4 (* addition is associative in C *)
+  | Add -> 4, 4, 3
   | Sub -> 4, 4, 3
   | Div -> 3, 3, 2
   | Mult -> 3, 3, 2

--- a/test/pulse/Assoc.expected.c
+++ b/test/pulse/Assoc.expected.c
@@ -1,0 +1,35 @@
+/* krml header omitted for test repeatability */
+
+
+#include "Assoc.h"
+
+int32_t Assoc_test_r(int32_t x, int32_t y, int32_t z)
+{
+  return x + (y + z);
+}
+
+int32_t Assoc_test_r_(int32_t x, int32_t y, int32_t z)
+{
+  return x + (y - z);
+}
+
+int32_t Assoc_test_l(int32_t x, int32_t y, int32_t z)
+{
+  return x + y + z;
+}
+
+int32_t Assoc_test_l_(int32_t x, int32_t y, int32_t z)
+{
+  return x + y - z;
+}
+
+int32_t Assoc_test4(int32_t x, int32_t y, int32_t z, int32_t w)
+{
+  return x + y - (z + w);
+}
+
+int32_t Assoc_test4_(int32_t x, int32_t y, int32_t z, int32_t w)
+{
+  return x - y + (z - w);
+}
+

--- a/test/pulse/Assoc.fst
+++ b/test/pulse/Assoc.fst
@@ -1,0 +1,23 @@
+module Assoc
+
+open FStar.Int32
+
+let small_t = x:t{-100 < v x /\ v x < 100}
+
+let test_r (x y z : small_t) : t =
+  x +^ (y +^ z)
+
+let test_r' (x y z : small_t) : t =
+  x +^ (y -^ z)
+
+let test_l (x y z : small_t) : t =
+  (x +^ y) +^ z
+
+let test_l' (x y z : small_t) : t =
+  (x +^ y) -^ z
+
+let test4 (x y z w : small_t) : t =
+  (x +^ y) -^ (z +^ w)
+
+let test4' (x y z w : small_t) : t =
+  (x -^ y) +^ (z -^ w)


### PR DESCRIPTION
Addition is not associative since changing it can affect overflow behavior, and cause UB in signed ints. Tweak the precedence levels to make sure we insert parenthesis except on left-to-right.

This is an example diff before and after the patch:
```
--- b/test/pulse/Assoc.expected.c
+++ a/test/pulse/Assoc.expected.c
@@ -5,7 +5,7 @@

 int32_t Assoc_test_r(int32_t x, int32_t y, int32_t z)
 {
-  return x + y - z;
+  return x + (y - z);
 }

 int32_t Assoc_test_l(int32_t x, int32_t y, int32_t z)
@@ -20,6 +20,6 @@ int32_t Assoc_test4(int32_t x, int32_t y, int32_t z, int32_t w)

 int32_t Assoc_test4_(int32_t x, int32_t y, int32_t z, int32_t w)
 {
-  return x - y + z - w;
+  return x - y + (z - w);
 }
```