### PR TITLE
CI: add apt-get update call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
         working-directory: karamel
         run: |
           eval $(opam env)
+          sudo apt-get update
           sudo apt-get install -y python3-sphinx python3-sphinx-rtd-theme
           make -C book html
 


### PR DESCRIPTION
CI has been failing to get some packages needed to build the book. Just missing an apt-get update.