### PR TITLE
PrintCommon: do not add _t suffix for float/double

### DIFF
--- a/lib/PrintCommon.ml
+++ b/lib/PrintCommon.ml
@@ -32,12 +32,16 @@ let width_to_string = function
   | Int64 -> if !Options.linux_ints then "s64" else "int64"
   | SizeT -> if !Options.linux_ints then "size_t" else "size"
   | PtrdiffT -> if !Options.linux_ints then "ptrdiff_t" else "ptrdiff"
-  | Float32 -> "float32"
-  | Float64 -> "float64"
+  | Float32 -> "float"
+  | Float64 -> "double"
 
 let print_width w =
-  string (width_to_string w) ^^
-  (if !Options.linux_ints then empty else string "_t")
+  if is_float w then
+    (* Floating-point types never get a _t suffix. *)
+    string (width_to_string w)
+  else
+    string (width_to_string w) ^^
+    (if !Options.linux_ints then empty else string "_t")
 
 let print_constant = function
   | w, s -> string s ^^ print_width w

--- a/test/pulse/Floats.expected.c
+++ b/test/pulse/Floats.expected.c
@@ -1,0 +1,15 @@
+/* krml header omitted for test repeatability */
+
+
+#include "Floats.h"
+
+float Floats_neg32(float x)
+{
+  return (float)0LL - x;
+}
+
+double Floats_neg64(double x)
+{
+  return (double)0LL - x;
+}
+

--- a/test/pulse/Floats.fst
+++ b/test/pulse/Floats.fst
@@ -1,0 +1,7 @@
+module Floats
+
+module F32 = FStar.Float32
+module F64 = FStar.Float64
+
+let neg32 (x : F32.t) : F32.t = F32.zero `F32.sub` x
+let neg64 (x : F64.t) : F64.t = F64.zero `F64.sub` x


### PR DESCRIPTION
This code currently prints float32_t and float64_t for Float32/Float64. Change it to use float/double, the usual C types. The `width_to_string` function is unchanged (it's called from GenCTypes, and I'm not sure if it's relying on current behavior).