### PR TITLE
Pulse tests: do not define `KRML_HOME` for CI; add `divergent` or `decreases` clauses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,9 @@ jobs:
         with:
           node-version: 16
 
-      - run: echo "KRML_HOME=$(pwd)/karamel" >> $GITHUB_ENV
+      - run: |
+         echo "FSTAR_USE_KRML_EXE=1" >> $GITHUB_ENV
+         echo "KRML_EXE=$(pwd)/karamel/out/bin/krml" >> $GITHUB_ENV
 
       - name: Karamel CI (test-pulse)
         working-directory: karamel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,10 +294,6 @@ jobs:
         with:
           node-version: 16
 
-      - run: |
-         echo "FSTAR_USE_KRML_EXE=1" >> $GITHUB_ENV
-         echo "KRML_EXE=$(pwd)/karamel/out/bin/krml" >> $GITHUB_ENV
-
       - name: Karamel CI (test-pulse)
         working-directory: karamel
         run: |

--- a/test/pulse/Break.fst
+++ b/test/pulse/Break.fst
@@ -9,12 +9,13 @@ fn simple_break ()
   while (!k)
     invariant live k
     ensures true
+    decreases (if !k then 1 else 0)
   {
     break;
   }
 }
 
-fn break_continue_and_return (which: UInt8.t)
+divergent fn break_continue_and_return (which: UInt8.t)
 {
   let mut i = 0ul;
   while (!i `UInt32.lt` 1000ul)
@@ -48,6 +49,7 @@ fn find_zero_with_break (a: array Int32.t) (sz: SizeT.t)
     invariant pure (SizeT.v !i <= SizeT.v sz /\
       (forall (j: nat). j < SizeT.v (!i) ==> Seq.index 'va j <> 0l))
     ensures (SizeT.v !i < SizeT.v sz /\ a.(!i) = 0l)
+    decreases (SizeT.v sz - SizeT.v (!i))
   {
     if (a.(!i) = 0l) {
       break;

--- a/test/pulse/Goto.fst
+++ b/test/pulse/Goto.fst
@@ -29,6 +29,7 @@ fn find_zero (a: array Int32.t) (sz: SizeT.t)
     invariant live i
     invariant pure (SizeT.v !i <= SizeT.v sz /\
       (forall (j: nat). j < SizeT.v (!i) ==> Seq.index 'va j <> 0l))
+    decreases (SizeT.v sz - SizeT.v (!i))
   {
     if (a.(!i) = 0l) {
       return !i;

--- a/test/pulse/Inline.fst
+++ b/test/pulse/Inline.fst
@@ -60,6 +60,8 @@ fn tst (shared : UInt32.t)
   let mut i = 0ul;
   while (!i <^ uu__k)
     invariant live i
+    invariant pure (v (!i) <= v uu__k)
+    decreases (Prims.op_Subtraction (v uu__k) (v (!i)))
   {
     i := !i +^ 1ul;
   };

--- a/test/pulse/InlineLoopCond.fst
+++ b/test/pulse/InlineLoopCond.fst
@@ -3,7 +3,7 @@ module InlineLoopCond
 #lang-pulse
 open Pulse
 
-fn test (f : unit -> fn returns UInt32.t)
+divergent fn test (f : unit -> fn returns UInt32.t)
   returns UInt32.t
 {
   let uu__  = f ();
@@ -15,7 +15,7 @@ fn test (f : unit -> fn returns UInt32.t)
   0ul
 }
 
-fn test_ok (x : UInt32.t)
+divergent fn test_ok (x : UInt32.t)
   returns UInt32.t
 {
   (* This one could be inlined (it's not at the moment) *)


### PR DESCRIPTION
## Summary

This branch tracks two recent F\* changes so that KaRaMeL's Pulse test suite
(`build-and-test-pulse`) keeps building and passing against F\* `master`:

- **FStarLang/FStar#4349** — F\* migrated from `KRML_HOME` to `KRML_EXE`.
- **FStarLang/FStar#4358** — Pulse split its computation type `stt` into a
  terminating `stt` (surface keyword `fn`) and a possibly-divergent `stt_div`
  (surface keyword `divergent fn`).

## Changes

### 1. CI: do not use `KRML_HOME` (follows FStarLang/FStar#4349)

`.github/workflows/ci.yml` — the `test-pulse` job no longer needs `KRML_HOME`. The current `test/pulse/Makefile` uses the proper Karamel executable for `KRML_EXE`.

### 2. `test/pulse`: adapt to the Pulse `stt`/`stt_div` split (follows FStarLang/FStar#4358)

**Root cause.** After #4358, a `while` loop (or `fn rec`) with no `decreases`
measure is a *divergent* (`stt_div`) computation. A plain `fn` must be
terminating (`stt`), so it can no longer contain a measure-free loop and now
fails with:

```
Error 228: Cannot compose computations in this divergent block:
  - This computation has effect: 'stt_div'
  - The continuation has effect: 'stt'
```

This broke `Inline.fst`, `InlineLoopCond.fst`, `Goto.fst` and `Break.fst`.

**Fix.** Following the same conventions F\* used to migrate its own Pulse
libraries and examples in #4358:

- Genuinely non-terminating loops are marked **`divergent fn`**.
- Terminating loops get a **`decreases`** measure (placed after the
  `invariant`/`ensures` clauses) so they stay plain terminating `fn`s.

| File · function | Loop nature | Fix |
|-----------------|-------------|-----|
| `InlineLoopCond.test`, `InlineLoopCond.test_ok` | Infinite — immutable condition, empty body | `divergent fn` |
| `Break.break_continue_and_return` | Infinite — a `continue` path never advances the counter | `divergent fn` |
| `Break.simple_break` | Terminating (break-only body) | `decreases (if !k then 1 else 0)` |
| `Break.find_zero_with_break` | Terminating count up to `sz` | `decreases (SizeT.v sz - SizeT.v (!i))` |
| `Goto.find_zero` | Terminating count up to `sz` | `decreases (SizeT.v sz - SizeT.v (!i))` |
| `Inline.tst` | Terminating count up to `uu__k` | bound invariant `pure (v (!i) <= v uu__k)` + `decreases (v uu__k - v (!i))` |

## Testing

`make -kj$(nproc) test-pulse` (the exact CI target) passes from a clean state:
all `CHECK`, `EXTRACT`, `KRML` and `DIFF` steps succeed.

Extraction is unaffected — `stt_div` extracts like `stt` — so the generated C
is unchanged and **no `*.expected.c` files needed updating**.

## Notes

- No changes outside `.github/workflows/ci.yml` and `test/pulse/`.
